### PR TITLE
Update ConfigDef to have more metadata and use it for validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ BatchSize=100
 * You need to have an Azure IoT Hub from which you want to copy data to Kafka. Get started
   [here](https://docs.microsoft.com/en-us/azure/iot-hub/).
 
-* You also need to have Apache Kafka installed and running. Get started
+* You also need to have Apache Kafka v0.10 installed and running. Get started
 [here](https://kafka.apache.org/documentation#quickstart).
 
 ###### Steps

--- a/build.sbt
+++ b/build.sbt
@@ -19,8 +19,8 @@ libraryDependencies ++= {
   val json4sVersion = "3.5.0"
 
   Seq(
-    "org.apache.kafka" % "connect-api" % kafkaVersion,
-    "org.apache.kafka" % "connect-json" % kafkaVersion,
+    "org.apache.kafka" % "connect-api" % kafkaVersion % "provided",
+    "org.apache.kafka" % "connect-json" % kafkaVersion % "provided",
     "com.microsoft.azure" % "azure-eventhubs" % azureEventHubSDKVersion,
     "org.json4s" %% "json4s-jackson" % json4sVersion,
     "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingVersion,

--- a/src/main/scala/com/microsoft/azure/iot/iothub2kafka/IotHubSourceConfig.scala
+++ b/src/main/scala/com/microsoft/azure/iot/iothub2kafka/IotHubSourceConfig.scala
@@ -3,9 +3,16 @@
 package com.microsoft.azure.iot.kafka.connect
 
 import com.microsoft.azure.eventhubs.EventHubClient
-import org.apache.kafka.common.config.ConfigDef
+import org.apache.kafka.common.config.ConfigDef.{Importance, Type, Width}
+import org.apache.kafka.common.config.{AbstractConfig, ConfigDef}
+
+import scala.collection.JavaConversions._
 
 object IotHubSourceConfig {
+
+  private val defaultBatchSize = 100
+  private val iotConfigGroup   = "Azure IoT Hub"
+  private val kafkaConfig      = "Kafka"
 
   val EventHubCompatibleConnectionString = "IotHub.EventHubCompatibleConnectionString"
   val EventHubCompatibleName             = "IotHub.EventHubCompatibleName"
@@ -30,27 +37,38 @@ object IotHubSourceConfig {
   val BatchSizeDoc                       = "The batch size for fetching records from IoT Hub"
   val IotHubOffset                       = "IotHub.Offsets"
   val IotHubOffsetDoc                    =
-    "Offset for each partition in IotHub. This value is ignored if IotHubStartTime is specified."
+    "Offset for each partition in IotHub, as a comma separated string. This value is ignored if IotHubStartTime is specified."
   val IotHubStartTime                    = "IotHub.StartTime"
   val IotHubStartTimeDoc                 = "The time after which to process messages from IoT Hub If this value " +
     "is specified, IotHubOffset value is ignored."
   val TaskPartitionOffsetsMap            = "TaskPartitions"
-  private val defaultBatchSize = 100
 
-  def getConfig: ConfigDef = {
+  lazy val configDef = new ConfigDef()
+    .define(EventHubCompatibleName, Type.STRING, Importance.HIGH, EventHubCompatibleNameDoc, iotConfigGroup, 1, Width
+      .MEDIUM, "Event Hub compatible name")
+    .define(EventHubCompatibleNamespace, Type.STRING, Importance.HIGH, EventHubCompatibleNamespaceDoc,
+      iotConfigGroup, 2, Width.MEDIUM, "Event Hub compatible namespace")
+    .define(IotHubAccessKeyName, Type.STRING, Importance.HIGH, IotHubAccessKeyNameDoc, iotConfigGroup, 3, Width.SHORT,
+      "Access key name")
+    .define(IotHubAccessKeyValue, Type.STRING, Importance.HIGH, IotHubAccessKeyValueDoc, iotConfigGroup, 4,
+      Width.LONG, "Access key value")
+    .define(IotHubConsumerGroup, Type.STRING, EventHubClient.DEFAULT_CONSUMER_GROUP_NAME, Importance.MEDIUM,
+      IotHubConsumerGroupDoc, iotConfigGroup, 5, Width.SHORT, "Consumer group")
+    .define(IotHubPartitions, Type.INT, Importance.HIGH, IotHubPartitionsDoc, iotConfigGroup, 6, Width.SHORT,
+      "IoT Hub partitions")
+    .define(IotHubStartTime, Type.STRING, "", Importance.MEDIUM, IotHubStartTimeDoc, iotConfigGroup, 7, Width.MEDIUM,
+      "Start time")
+    .define(IotHubOffset, Type.STRING, "", Importance.MEDIUM, IotHubOffsetDoc, iotConfigGroup, 8, Width.MEDIUM,
+      "Per partition offsets")
+    .define(BatchSize, Type.INT, defaultBatchSize, Importance.MEDIUM, IotHubOffsetDoc, iotConfigGroup, 9, Width.SHORT,
+      "Batch size")
+    .define(KafkaTopic, Type.STRING, Importance.HIGH, KafkaTopicDoc, kafkaConfig, 10, Width.MEDIUM, "Kafka topic")
 
-    val config = new ConfigDef
-    config.define(EventHubCompatibleName, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, EventHubCompatibleNameDoc)
-    config.define(EventHubCompatibleNamespace, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH,
-      EventHubCompatibleNamespaceDoc)
-    config.define(IotHubAccessKeyName, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, IotHubAccessKeyNameDoc)
-    config.define(IotHubAccessKeyValue, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, IotHubAccessKeyValueDoc)
-    config.define(IotHubConsumerGroup, ConfigDef.Type.STRING, EventHubClient.DEFAULT_CONSUMER_GROUP_NAME,
-      ConfigDef.Importance.MEDIUM, IotHubConsumerGroupDoc)
-    config.define(IotHubPartitions, ConfigDef.Type.INT, ConfigDef.Importance.HIGH, IotHubPartitionsDoc)
-    config.define(KafkaTopic, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, KafkaTopicDoc)
-    config.define(IotHubOffset, ConfigDef.Type.STRING, "", ConfigDef.Importance.MEDIUM, IotHubOffsetDoc)
-    config.define(IotHubStartTime, ConfigDef.Type.STRING, "", ConfigDef.Importance.MEDIUM, IotHubStartTimeDoc)
-    config.define(BatchSize, ConfigDef.Type.INT, defaultBatchSize, ConfigDef.Importance.MEDIUM, IotHubOffsetDoc)
+  def getConfig(configValues: Map[String, String]): IotHubSourceConfig = {
+    new IotHubSourceConfig(configDef, configValues)
   }
 }
+
+class IotHubSourceConfig(configDef: ConfigDef, configValues: Map[String, String])
+  extends AbstractConfig(configDef, configValues)
+

--- a/src/test/scala/com/microsoft/azure/iot/iothub2kafka/IotHubSourceConnectorTest.scala
+++ b/src/test/scala/com/microsoft/azure/iot/iothub2kafka/IotHubSourceConnectorTest.scala
@@ -3,7 +3,7 @@
 package com.microsoft.azure.iot.kafka.connect
 
 import com.microsoft.azure.iot.kafka.connect.testhelpers.TestConfig
-import org.apache.kafka.common.config.ConfigException
+import org.apache.kafka.connect.errors.ConnectException
 import org.json4s.jackson.Serialization.read
 import org.scalatest.{FlatSpec, GivenWhenThen}
 
@@ -56,7 +56,7 @@ class IotHubSourceConnectorTest extends FlatSpec with GivenWhenThen with JsonSer
     val connector = new IotHubSourceConnector
 
     When("IotHubSourceConnector.Start is called, ConfigException is thrown")
-    intercept[ConfigException] {
+    intercept[ConnectException] {
       connector.start(inputProperties)
     }
   }

--- a/src/test/scala/com/microsoft/azure/iot/iothub2kafka/IotHubSourceTaskTest.scala
+++ b/src/test/scala/com/microsoft/azure/iot/iothub2kafka/IotHubSourceTaskTest.scala
@@ -11,6 +11,8 @@ import org.scalatest.{FlatSpec, GivenWhenThen}
 
 class IotHubSourceTaskTest extends FlatSpec with GivenWhenThen with JsonSerialization {
 
+  // This test is ignored as the configuration values in the test application.conf has no values.
+  // After entering the right values, this test can be run.
   "IotHubSourceTask start"
   ignore should "initialize all properties" in {
 

--- a/src/test/scala/com/microsoft/azure/iot/iothub2kafka/IotHubSourceTaskTest.scala
+++ b/src/test/scala/com/microsoft/azure/iot/iothub2kafka/IotHubSourceTaskTest.scala
@@ -11,10 +11,10 @@ import org.scalatest.{FlatSpec, GivenWhenThen}
 
 class IotHubSourceTaskTest extends FlatSpec with GivenWhenThen with JsonSerialization {
 
-  // This test is ignored as the configuration values in the test application.conf has no values.
-  // After entering the right values, this test can be run.
+  // This test is ignored as the configuration in the test application.conf has no values.
+  // After updating the application.conf with the right values, this test can be run.
   "IotHubSourceTask start"
-  ignore should "initialize all properties" in {
+  it should "initialize all properties" in {
 
     Given("A list of properties for IotHubSourceTask")
     val props: util.Map[String, String] = TestConfig.sourceTaskTestProps


### PR DESCRIPTION
- Added more metadata to the connector ConfigDef for use with control center
- Extending from AbstractConfig to be able to use it for parsing and validation.
- Also marked Kafka dependencies as "provided" in sbt to avoid packaging them in the jar.