### PR TITLE
Schema update for IoT messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,14 +98,74 @@ on this topic.
 
 ### Data format
 
-The data in the IoT Hub is retrieved and pumped into the specified Kafka topic as a JSON blob string, with the following
- format. This allows data with any schema to be copied over to Kafka for consumption downstream.
+The data in the IoT Hub is retrieved and pumped into the specified Kafka topic with the following schema. Note that it contains the most relevant properties at the top level (like deviceId, offset, enqueuedTime, sequenceNumber, etc.). While all these properties are set by IoT Hub, contentType needs to be set by the device. The actual payload from the device is contained in the "content" property as a JSON blob. This allows payload with any schema to be copied over to Kafka for consumption downstream. 
 
 ```json
 {
-  "content":"The raw content sent by the device",
-  "systemProperties":"Map of key-value pairs containing system properties",
-  "properties":"Map of key-value pairs containing any custom properties set by the device"
+  "schema": {
+    "type": "struct",
+    "fields": [
+      {
+        "type": "string",
+        "optional": false,
+        "field": "deviceId"
+      },
+      {
+        "type": "string",
+        "optional": false,
+        "field": "offset"
+      },
+      {
+        "type": "string",
+        "optional": true,
+        "field": "contentType"
+      },
+      {
+        "type": "string",
+        "optional": false,
+        "field": "enqueuedTime"
+      },
+      {
+        "type": "int64",
+        "optional": false,
+        "field": "sequenceNumber"
+      },
+      {
+        "type": "string",
+        "optional": false,
+        "field": "content"
+      },
+      {
+        "type": "map",
+        "keys": {
+          "type": "string",
+          "optional": false
+        },
+        "values": {
+          "type": "string",
+          "optional": false
+        },
+        "optional": false,
+        "field": "systemProperties"
+      },
+      {
+        "type": "map",
+        "keys": {
+          "type": "string",
+          "optional": false
+        },
+        "values": {
+          "type": "string",
+          "optional": false
+        },
+        "optional": false,
+        "field": "properties"
+      }
+    ],
+    "optional": false,
+    "name": "iothub.kafka.connect",
+    "version": 1
+  }
 }
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,8 @@ libraryDependencies ++= {
   )
 }
 
+assemblyJarName in assembly := "kafka-connect-iothub-assembly_2.11-0.5.jar"
+
 publishArtifact in Test := true
 publishArtifact in(Compile, packageDoc) := true
 publishArtifact in(Compile, packageSrc) := true

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+val iotHubKafkaConnectVersion = "0.5"
+
 name := "kafka-connect-iothub"
 organization := "com.microsoft.azure.iot"
-version := "0.5"
+version := iotHubKafkaConnectVersion
 
 scalaVersion := "2.11.8"
 
@@ -32,7 +34,7 @@ libraryDependencies ++= {
   )
 }
 
-assemblyJarName in assembly := "kafka-connect-iothub-assembly_2.11-0.5.jar"
+assemblyJarName in assembly := s"kafka-connect-iothub-assembly_2.11-$iotHubKafkaConnectVersion.jar"
 
 publishArtifact in Test := true
 publishArtifact in(Compile, packageDoc) := true

--- a/src/main/scala/com/microsoft/azure/iot/iothub2kafka/EventHubReceiver.scala
+++ b/src/main/scala/com/microsoft/azure/iot/iothub2kafka/EventHubReceiver.scala
@@ -6,7 +6,7 @@ import java.time.Instant
 
 import com.microsoft.azure.eventhubs.{EventHubClient, PartitionReceiver}
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 
 class EventHubReceiver(val connectionString: String, val receiverConsumerGroup: String, val partition: String,
@@ -38,11 +38,11 @@ class EventHubReceiver(val connectionString: String, val receiverConsumerGroup: 
     var curBatchSize = batchSize
     var endReached = false
     while (curBatchSize > 0 && !endReached) {
-      val batch = this.eventHubReceiver.receiveSync(curBatchSize)
+      val batch = this.eventHubReceiver.receiveSync(curBatchSize).asScala
       if (batch != null && batch.nonEmpty) {
         iotMessages ++= batch.map(e => {
           val content = new String(e.getBody)
-          val iotDeviceData = IotMessage(content, e.getSystemProperties, e.getProperties)
+          val iotDeviceData = IotMessage(content, e.getSystemProperties.asScala, e.getProperties.asScala)
           iotDeviceData
         })
         curBatchSize -= batch.size

--- a/src/main/scala/com/microsoft/azure/iot/iothub2kafka/EventHubReceiver.scala
+++ b/src/main/scala/com/microsoft/azure/iot/iothub2kafka/EventHubReceiver.scala
@@ -7,7 +7,6 @@ import java.time.Instant
 import com.microsoft.azure.eventhubs.{EventHubClient, PartitionReceiver}
 
 import scala.collection.JavaConversions._
-import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 
 class EventHubReceiver(val connectionString: String, val receiverConsumerGroup: String, val partition: String,
@@ -43,13 +42,8 @@ class EventHubReceiver(val connectionString: String, val receiverConsumerGroup: 
       if (batch != null && batch.nonEmpty) {
         iotMessages ++= batch.map(e => {
           val content = new String(e.getBody)
-          val systemProps = e.getSystemProperties.map(i => (i._1, i._2.toString))
-          val properties = e.getProperties.asScala
-          val deviceId = systemProps.get("iothub-connection-device-id").toString
-          val offset = e.getSystemProperties.getOffset
-          val iotMessageData = IotMessageData(content, systemProps.toMap, properties.toMap)
-          val iotMessage = IotMessage(iotMessageData, deviceId, offset)
-          iotMessage
+          val iotDeviceData = IotMessage(content, e.getSystemProperties, e.getProperties)
+          iotDeviceData
         })
         curBatchSize -= batch.size
       } else {

--- a/src/main/scala/com/microsoft/azure/iot/iothub2kafka/IotHubPartitionSource.scala
+++ b/src/main/scala/com/microsoft/azure/iot/iothub2kafka/IotHubPartitionSource.scala
@@ -2,7 +2,6 @@
 
 package com.microsoft.azure.iot.kafka.connect
 
-import java.util
 import java.util.Collections
 
 import com.typesafe.scalalogging.LazyLogging
@@ -10,7 +9,6 @@ import org.apache.kafka.connect.data.Struct
 import org.apache.kafka.connect.errors.ConnectException
 import org.apache.kafka.connect.source.SourceRecord
 
-import scala.collection.JavaConversions._
 import scala.collection.mutable.ListBuffer
 import scala.util.control.NonFatal
 
@@ -21,7 +19,7 @@ class IotHubPartitionSource(val dataReceiver: DataReceiver,
   extends LazyLogging
     with JsonSerialization {
 
-  def getRecords: util.List[SourceRecord] = {
+  def getRecords: List[SourceRecord] = {
 
     logger.debug(s"Polling for data from Partition $partition")
     val list = ListBuffer.empty[SourceRecord]
@@ -43,7 +41,7 @@ class IotHubPartitionSource(val dataReceiver: DataReceiver,
             kafkaMessage.getString(IotMessageConverter.offsetKey))
           val sourceRecord = new SourceRecord(sourcePartitionKey, sourceOffset, this.topic, kafkaMessage.schema(),
             kafkaMessage)
-          list.add(sourceRecord)
+          list += sourceRecord
         }
       }
     } catch {
@@ -54,6 +52,6 @@ class IotHubPartitionSource(val dataReceiver: DataReceiver,
         throw new ConnectException(errorMsg, e)
     }
     logger.debug(s"Obtained ${list.length} SourceRecords from IotHub")
-    list
+    list.toList
   }
 }

--- a/src/main/scala/com/microsoft/azure/iot/iothub2kafka/IotHubSourceConfig.scala
+++ b/src/main/scala/com/microsoft/azure/iot/iothub2kafka/IotHubSourceConfig.scala
@@ -6,7 +6,7 @@ import com.microsoft.azure.eventhubs.EventHubClient
 import org.apache.kafka.common.config.ConfigDef.{Importance, Type, Width}
 import org.apache.kafka.common.config.{AbstractConfig, ConfigDef}
 
-import scala.collection.JavaConversions._
+import java.util.Map
 
 object IotHubSourceConfig {
 

--- a/src/main/scala/com/microsoft/azure/iot/iothub2kafka/IotHubSourceConnector.scala
+++ b/src/main/scala/com/microsoft/azure/iot/iothub2kafka/IotHubSourceConnector.scala
@@ -14,7 +14,6 @@ import org.apache.kafka.connect.source.SourceConnector
 import org.json4s.jackson.Serialization.write
 
 import scala.collection.JavaConverters._
-import collection.JavaConversions._
 import scala.collection.mutable
 
 class IotHubSourceConnector extends SourceConnector with LazyLogging with JsonSerialization {
@@ -74,7 +73,7 @@ class IotHubSourceConnector extends SourceConnector with LazyLogging with JsonSe
     var iotHubSourceConfigOption: Option[IotHubSourceConfig] = None
 
     try {
-      iotHubSourceConfigOption = Some(IotHubSourceConfig.getConfig(props.toMap))
+      iotHubSourceConfigOption = Some(IotHubSourceConfig.getConfig(props))
     } catch {
       case ex: ConfigException ⇒ throw new ConnectException("Could not start IotHubSourceConnector due to a " +
         "configuration exception", ex)

--- a/src/main/scala/com/microsoft/azure/iot/iothub2kafka/IotHubSourceTask.scala
+++ b/src/main/scala/com/microsoft/azure/iot/iothub2kafka/IotHubSourceTask.scala
@@ -7,6 +7,7 @@ import java.util
 import java.util.Collections
 
 import com.typesafe.scalalogging.LazyLogging
+import org.apache.kafka.connect.errors.ConnectException
 import org.apache.kafka.connect.source.{SourceRecord, SourceTask}
 import org.json4s.jackson.Serialization.read
 
@@ -33,7 +34,7 @@ class IotHubSourceTask extends SourceTask with LazyLogging with JsonSerializatio
       case NonFatal(e) =>
         val errorMsg = s"Error while polling for data. Exception - ${e.toString} Stack trace - ${e.printStackTrace()}"
         logger.error(errorMsg)
-        throw e
+        throw new ConnectException("Error while polling for data", e)
     }
     logger.info(s"Polling for data - Obtained ${list.length} SourceRecords from IotHub")
     list

--- a/src/main/scala/com/microsoft/azure/iot/iothub2kafka/IotHubSourceTask.scala
+++ b/src/main/scala/com/microsoft/azure/iot/iothub2kafka/IotHubSourceTask.scala
@@ -11,7 +11,7 @@ import org.apache.kafka.connect.errors.ConnectException
 import org.apache.kafka.connect.source.{SourceRecord, SourceTask}
 import org.json4s.jackson.Serialization.read
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.control.NonFatal
 
@@ -37,7 +37,7 @@ class IotHubSourceTask extends SourceTask with LazyLogging with JsonSerializatio
         throw new ConnectException("Error while polling for data", e)
     }
     logger.info(s"Polling for data - Obtained ${list.length} SourceRecords from IotHub")
-    list
+    list.asJava
   }
 
   override def start(props: util.Map[String, String]): Unit = {

--- a/src/main/scala/com/microsoft/azure/iot/iothub2kafka/IotMessage.scala
+++ b/src/main/scala/com/microsoft/azure/iot/iothub2kafka/IotMessage.scala
@@ -2,6 +2,5 @@
 
 package com.microsoft.azure.iot.kafka.connect
 
-case class IotMessage(data: IotMessageData, deviceId: String, offset: String)
-
-case class IotMessageData(content: String, systemProperties: Map[String, String], properties: Map[String, String])
+case class IotMessage(content: String, systemProperties: scala.collection.mutable.Map[String, Object],
+    properties: scala.collection.mutable.Map[String, String])

--- a/src/main/scala/com/microsoft/azure/iot/iothub2kafka/IotMessageConverter.scala
+++ b/src/main/scala/com/microsoft/azure/iot/iothub2kafka/IotMessageConverter.scala
@@ -13,6 +13,19 @@ import scala.reflect.ClassTag
 
 object IotMessageConverter {
 
+  val offsetKey = "offset"
+
+  private val schemaName          = "iothub.kafka.connect"
+  private val schemaVersion       = 1
+  private val deviceIdKey         = "deviceId"
+  private val contentTypeKey      = "contentType"
+  private val sequenceNumberKey   = "sequenceNumber"
+  private val enqueuedTimeKey     = "enqueuedTime"
+  private val contentKey          = "content"
+  private val systemPropertiesKey = "systemProperties"
+  private val propertiesKey       = "properties"
+  private val deviceIdIotHubKey   = "iothub-connection-device-id"
+
   // Public for testing purposes
   lazy val schema: Schema = SchemaBuilder.struct()
     .name(schemaName)
@@ -27,19 +40,6 @@ object IotMessageConverter {
     .field(propertiesKey, propertiesMapSchema)
 
   private lazy val propertiesMapSchema: Schema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA)
-
-  val offsetKey = "offset"
-
-  private val schemaName          = "iothub.kafka.connect"
-  private val schemaVersion       = 1
-  private val deviceIdKey         = "deviceId"
-  private val contentTypeKey      = "contentType"
-  private val sequenceNumberKey   = "sequenceNumber"
-  private val enqueuedTimeKey     = "enqueuedTime"
-  private val contentKey          = "content"
-  private val systemPropertiesKey = "systemProperties"
-  private val propertiesKey       = "properties"
-  private val deviceIdIotHubKey   = "iothub-connection-device-id"
 
   def getIotMessageStruct(iotMessage: IotMessage): Struct = {
 

--- a/src/main/scala/com/microsoft/azure/iot/iothub2kafka/IotMessageConverter.scala
+++ b/src/main/scala/com/microsoft/azure/iot/iothub2kafka/IotMessageConverter.scala
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package com.microsoft.azure.iot.kafka.connect
+
+import java.time.Instant
+import java.util.Date
+
+import com.microsoft.azure.servicebus.amqp.AmqpConstants
+import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
+
+import scala.collection.JavaConverters._
+import scala.reflect.ClassTag
+
+object IotMessageConverter {
+
+  // Public for testing purposes
+  lazy val schema: Schema = SchemaBuilder.struct()
+    .name(schemaName)
+    .version(schemaVersion)
+    .field(deviceIdKey, Schema.STRING_SCHEMA)
+    .field(offsetKey, Schema.STRING_SCHEMA)
+    .field(contentTypeKey, Schema.OPTIONAL_STRING_SCHEMA)
+    .field(enqueuedTimeKey, Schema.STRING_SCHEMA)
+    .field(sequenceNumberKey, Schema.INT64_SCHEMA)
+    .field(contentKey, Schema.STRING_SCHEMA)
+    .field(systemPropertiesKey, propertiesMapSchema)
+    .field(propertiesKey, propertiesMapSchema)
+
+  private lazy val propertiesMapSchema: Schema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA)
+
+  val offsetKey = "offset"
+
+  private val schemaName          = "iothub.kafka.connect"
+  private val schemaVersion       = 1
+  private val deviceIdKey         = "deviceId"
+  private val contentTypeKey      = "contentType"
+  private val sequenceNumberKey   = "sequenceNumber"
+  private val enqueuedTimeKey     = "enqueuedTime"
+  private val contentKey          = "content"
+  private val systemPropertiesKey = "systemProperties"
+  private val propertiesKey       = "properties"
+  private val deviceIdIotHubKey   = "iothub-connection-device-id"
+
+  def getIotMessageStruct(iotMessage: IotMessage): Struct = {
+
+    val systemProperties = iotMessage.systemProperties
+    val deviceId: String = getOrDefaultAndRemove(systemProperties, deviceIdIotHubKey, "")
+    val offset: String = getOrDefaultAndRemove(systemProperties, AmqpConstants.OFFSET_ANNOTATION_NAME, "")
+    val sequenceNumber: Long = getOrDefaultAndRemove(systemProperties, AmqpConstants.SEQUENCE_NUMBER_ANNOTATION_NAME, 0)
+    val enqueuedTime: Option[Instant] = getEnqueuedTime(systemProperties)
+    val enqueuedTimeStr = if(enqueuedTime.isDefined) enqueuedTime.get.toString else ""
+
+    val properties = iotMessage.properties
+    val contentType: String = getOrDefaultAndRemove(properties, contentTypeKey, "")
+
+    val systemPropertiesMap = systemProperties.map(i => (i._1, i._2.toString))
+
+    new Struct(schema)
+      .put(deviceIdKey, deviceId)
+      .put(offsetKey, offset)
+      .put(contentTypeKey, contentType)
+      .put(enqueuedTimeKey, enqueuedTimeStr)
+      .put(sequenceNumberKey, sequenceNumber)
+      .put(contentKey, iotMessage.content)
+      .put(systemPropertiesKey, systemPropertiesMap.asJava)
+      .put(propertiesKey, properties.asJava)
+  }
+
+  private def getEnqueuedTime(map: scala.collection.mutable.Map[String, Object]): Option[Instant] = {
+    val enqueuedTimeValue: Date = getOrDefaultAndRemove(map, AmqpConstants.ENQUEUED_TIME_UTC_ANNOTATION_NAME, null)
+    if (enqueuedTimeValue != null) Some(enqueuedTimeValue.toInstant) else None
+  }
+
+  private def getOrDefaultAndRemove[T: ClassTag, S: ClassTag](map: scala.collection.mutable.Map[String, S],
+      key: String, defaultVal: T): T = {
+
+    if (map.contains(key)) {
+      val retVal: T = map(key).asInstanceOf[T]
+      map.remove(key)
+      retVal
+    } else {
+      defaultVal
+    }
+  }
+}

--- a/src/test/scala/com/microsoft/azure/iot/iothub2kafka/IotHubSourceTaskTest.scala
+++ b/src/test/scala/com/microsoft/azure/iot/iothub2kafka/IotHubSourceTaskTest.scala
@@ -2,17 +2,55 @@
 
 package com.microsoft.azure.iot.kafka.connect
 
+import java.time.Instant
 import java.util
 
-import com.microsoft.azure.iot.kafka.connect.testhelpers.{MockDataReceiver, TestConfig, TestIotHubSourceTask}
-import org.apache.kafka.connect.data.Schema
+import com.microsoft.azure.iot.kafka.connect.testhelpers.{DeviceTemperature, MockDataReceiver, TestConfig, TestIotHubSourceTask}
+import org.apache.kafka.connect.data.Struct
 import org.json4s.jackson.Serialization.read
 import org.scalatest.{FlatSpec, GivenWhenThen}
 
 class IotHubSourceTaskTest extends FlatSpec with GivenWhenThen with JsonSerialization {
 
-  // This test is ignored as the configuration in the test application.conf has no values.
-  // After updating the application.conf with the right values, this test can be run.
+  "IotHubSourceTask poll" should "return a list of SourceRecords with the right format" in {
+
+    Given("IotHubSourceTask instance")
+
+    val iotHubSourceTask = new TestIotHubSourceTask
+    iotHubSourceTask.start(TestConfig.sourceTaskTestProps)
+
+    When("IotHubSourceTask.poll is called")
+    val sourceRecords = iotHubSourceTask.poll()
+
+    Then("It returns a list of SourceRecords")
+    assert(sourceRecords != null)
+    assert(sourceRecords.size() == 15)
+    for (i <- 0 until 15) {
+      val record = sourceRecords.get(i)
+      assert(record.topic() == TestConfig.sourceTaskTestProps.get(IotHubSourceConfig.KafkaTopic))
+      assert(record.valueSchema() == IotMessageConverter.schema)
+      val messageStruct = record.value().asInstanceOf[Struct]
+      assert(messageStruct.getString("deviceId").startsWith("device"))
+      assert(messageStruct.getString("contentType") == "temperature")
+      val enqueuedTime = Instant.parse(messageStruct.getString("enqueuedTime"))
+      assert(enqueuedTime.isAfter(Instant.parse("2016-11-20T00:00:00Z")))
+
+      val systemProperties = messageStruct.getMap[String, String]("systemProperties")
+      assert(systemProperties != null)
+      assert(systemProperties.get("sequenceNumber") != "")
+      assert(systemProperties.get("correlationId") != "")
+
+      val properties = messageStruct.getMap[String, String]("properties")
+      assert(properties != null)
+      assert(properties.get("timestamp") != "")
+
+      val deviceTemperature = read[DeviceTemperature](messageStruct.get("content").asInstanceOf[String])
+      assert(deviceTemperature != null)
+      assert(deviceTemperature.unit == "F")
+      assert(deviceTemperature.value != 0)
+    }
+  }
+
   "IotHubSourceTask start"
   it should "initialize all properties" in {
 
@@ -26,34 +64,35 @@ class IotHubSourceTaskTest extends FlatSpec with GivenWhenThen with JsonSerializ
     Then("Data receiver should be properly initialized")
     assert(task.partitionSources.length == 3)
     assert(!task.partitionSources.exists(s => s.dataReceiver == null))
+    for (ps ← task.partitionSources) {
+      val dataReceiver = ps.dataReceiver.asInstanceOf[MockDataReceiver]
+      assert(dataReceiver.offset.isDefined)
+      assert(dataReceiver.startTime.isEmpty)
+      assert(dataReceiver.connectionString != "")
+      assert(dataReceiver.receiverConsumerGroup != "")
+    }
   }
 
-  "IotHubSourceTask poll" should "return a list of SourceRecords with the right format" in {
+  it should "initialize start time correctly on the data receiver when it is passed in the config" in {
 
-    Given("IotHubSourceTask instance")
+    Given("A list of properties with StartTime for IotHubSourceTask")
+    val props: util.Map[String, String] = TestConfig.sourceTaskTestPropsStartTime
 
-    val dataReceiver = new MockDataReceiver()
-    val iotHubSourceTask = new TestIotHubSourceTask
-    iotHubSourceTask.start(TestConfig.sourceTaskTestProps)
+    When("IotHubSourceTask is started")
+    val task = new TestIotHubSourceTask
+    task.start(props)
 
-    When("IotHubSourceTask.poll is called")
-    val sourceRecords = iotHubSourceTask.poll()
-
-    Then("It returns a list of SourceRecords")
-    assert(sourceRecords != null)
-    assert(sourceRecords.size() == 15)
-    for (i <- 0 until 15) {
-      val record = sourceRecords.get(i)
-      assert(record.topic() == TestConfig.sourceTaskTestProps.get(IotHubSourceConfig.KafkaTopic))
-      assert(record.valueSchema() == Schema.STRING_SCHEMA)
-      val kafkaMessageString = record.value().asInstanceOf[String]
-      val kafkaMessage = read[IotMessageData](kafkaMessageString)
-
-      assert(kafkaMessage.content != "")
-      assert(kafkaMessage.systemProperties != null)
-      assert(kafkaMessage.systemProperties.size == 2)
-      assert(kafkaMessage.properties != null)
-      assert(kafkaMessage.properties.size == 1)
+    Then("Data receiver should be properly initialized, with StartTime, while Offsets value should be ignored")
+    assert(task.partitionSources.length == 3)
+    assert(!task.partitionSources.exists(s => s.dataReceiver == null))
+    for (ps ← task.partitionSources) {
+      val dataReceiver = ps.dataReceiver.asInstanceOf[MockDataReceiver]
+      assert(dataReceiver.offset.isEmpty)
+      assert(dataReceiver.startTime.isDefined)
+      assert(dataReceiver.startTime.get == Instant.parse("2016-12-10T00:00:00Z"))
+      assert(dataReceiver.connectionString != "")
+      assert(dataReceiver.receiverConsumerGroup != "")
     }
   }
 }
+

--- a/src/test/scala/com/microsoft/azure/iot/iothub2kafka/IotMessageConverterTest.scala
+++ b/src/test/scala/com/microsoft/azure/iot/iothub2kafka/IotMessageConverterTest.scala
@@ -18,8 +18,8 @@ class IotMessageConverterTest extends FlatSpec with GivenWhenThen with JsonSeria
 
   private val random: Random = new Random
 
-  "IotMessage Converter"
-  it should "" in {
+  "IotMessage Converter" should "populate right values for kafka message struct fields" in {
+
     Given("IotMessage object")
     val deviceTemp = DeviceTemperature(100.01, "F")
     val deviceTempStr = write(deviceTemp)
@@ -66,6 +66,7 @@ class IotMessageConverterTest extends FlatSpec with GivenWhenThen with JsonSeria
   }
 
   it should "use default values for missing properties" in {
+
     val deviceTemp = DeviceTemperature(100.01, "F")
     val deviceTempStr = write(deviceTemp)
 

--- a/src/test/scala/com/microsoft/azure/iot/iothub2kafka/IotMessageConverterTest.scala
+++ b/src/test/scala/com/microsoft/azure/iot/iothub2kafka/IotMessageConverterTest.scala
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package com.microsoft.azure.iot.kafka.connect
+
+import java.text.SimpleDateFormat
+import java.time.Instant
+
+import com.microsoft.azure.iot.kafka.connect.testhelpers.DeviceTemperature
+import com.microsoft.azure.servicebus.amqp.AmqpConstants
+import org.apache.kafka.connect.data.Struct
+import org.json4s.jackson.Serialization._
+import org.scalatest.{FlatSpec, GivenWhenThen}
+
+import scala.collection.mutable
+import scala.util.Random
+
+class IotMessageConverterTest extends FlatSpec with GivenWhenThen with JsonSerialization {
+
+  private val random: Random = new Random
+
+  "IotMessage Converter"
+  it should "" in {
+    Given("IotMessage object")
+    val deviceTemp = DeviceTemperature(100.01, "F")
+    val deviceTempStr = write(deviceTemp)
+
+    val sequenceNumber = random.nextLong()
+    val correlationId = random.nextString(10)
+    val offset = random.nextString(10)
+    val enqueuedDate = new SimpleDateFormat("MM/dd/yyyy").parse("12/01/2016")
+    val systemProperties = mutable.Map[String, Object](
+      "iothub-connection-device-id" → "device10",
+      AmqpConstants.SEQUENCE_NUMBER_ANNOTATION_NAME → sequenceNumber.asInstanceOf[Object],
+      AmqpConstants.AMQP_PROPERTY_CORRELATION_ID → correlationId,
+      AmqpConstants.OFFSET_ANNOTATION_NAME → offset,
+      AmqpConstants.ENQUEUED_TIME_UTC_ANNOTATION_NAME → enqueuedDate)
+
+    val timestamp = Instant.now().toString
+    val messageProperties = mutable.Map[String, String](
+      "timestamp" → timestamp,
+      "contentType" → "temperature"
+    )
+
+    val iotMessage = IotMessage(deviceTempStr, systemProperties, messageProperties)
+
+    When("getIotMessageStruct is called with IotMessage object")
+    val kafkaMessageStruct: Struct = IotMessageConverter.getIotMessageStruct(iotMessage)
+
+    Then("The struct has all the expected properties")
+    assert(kafkaMessageStruct.getString("deviceId") == "device10")
+    assert(kafkaMessageStruct.getString("offset") == offset)
+    assert(kafkaMessageStruct.getString("contentType") == "temperature")
+    assert(kafkaMessageStruct.getString("enqueuedTime") == enqueuedDate.toInstant.toString)
+    assert(kafkaMessageStruct.getInt64("sequenceNumber") == sequenceNumber)
+    assert(kafkaMessageStruct.getString("content") == deviceTempStr)
+
+    val structSystemProperties = kafkaMessageStruct.getMap[String, String]("systemProperties")
+    assert(structSystemProperties != null)
+    assert(structSystemProperties.size == 1)
+    assert(structSystemProperties.get(AmqpConstants.AMQP_PROPERTY_CORRELATION_ID) == correlationId)
+
+    val structProperties = kafkaMessageStruct.getMap[String, String]("properties")
+    assert(structProperties != null)
+    assert(structProperties.size == 1)
+    assert(structProperties.get("timestamp") == timestamp)
+  }
+
+  it should "use default values for missing properties" in {
+    val deviceTemp = DeviceTemperature(100.01, "F")
+    val deviceTempStr = write(deviceTemp)
+
+    val systemProperties = mutable.Map.empty[String, Object]
+    val messageProperties = mutable.Map.empty[String, String]
+
+    val iotMessage = IotMessage(deviceTempStr, systemProperties, messageProperties)
+
+    When("getIotMessageStruct is called with IotMessage object")
+    val kafkaMessageStruct: Struct = IotMessageConverter.getIotMessageStruct(iotMessage)
+
+    Then("The struct has all the expected properties")
+    assert(kafkaMessageStruct.getString("deviceId") == "")
+    assert(kafkaMessageStruct.getString("offset") == "")
+    assert(kafkaMessageStruct.getString("contentType") == "")
+    assert(kafkaMessageStruct.getString("enqueuedTime") == "")
+    assert(kafkaMessageStruct.getInt64("sequenceNumber") == 0)
+    assert(kafkaMessageStruct.getString("content") == deviceTempStr)
+
+    val structSystemProperties = kafkaMessageStruct.getMap[String, String]("systemProperties")
+    assert(structSystemProperties != null)
+    assert(structSystemProperties.size == 0)
+
+    val structProperties = kafkaMessageStruct.getMap[String, String]("properties")
+    assert(structProperties != null)
+    assert(structProperties.size == 0)
+  }
+}

--- a/src/test/scala/com/microsoft/azure/iot/iothub2kafka/testhelpers/TestConfig.scala
+++ b/src/test/scala/com/microsoft/azure/iot/iothub2kafka/testhelpers/TestConfig.scala
@@ -20,6 +20,17 @@ object TestConfig {
     props
   }
 
+  lazy val sourceTaskTestPropsStartTime: util.Map[String, String] = {
+    val props = new util.HashMap[String, String]()
+    props.put(IotHubSourceConfig.EventHubCompatibleConnectionString, connStr.toString)
+    props.put(IotHubSourceConfig.IotHubConsumerGroup, "$Default")
+    props.put(IotHubSourceConfig.TaskPartitionOffsetsMap, """{"0":"5","2":"10","3":"-1"}""")
+    props.put(IotHubSourceConfig.IotHubStartTime, "2016-12-10T00:00:00Z")
+    props.put(IotHubSourceConfig.KafkaTopic, "test")
+    props.put(IotHubSourceConfig.BatchSize, "5")
+    props
+  }
+
   lazy val sourceSingleTaskTestProps: util.Map[String, String] = {
     val props = new util.HashMap[String, String]()
     props.put(IotHubSourceConfig.EventHubCompatibleConnectionString, connStr.toString)
@@ -39,6 +50,18 @@ object TestConfig {
     props.put(IotHubSourceConfig.IotHubPartitions, iotHubPartitions.toString)
     props.put(IotHubSourceConfig.KafkaTopic, "test")
     props.put(IotHubSourceConfig.IotHubOffset, "-1,5,10,15,-1")
+    props
+  }
+
+  lazy val sourceConnectorTestPropsStartTime: util.Map[String, String] = {
+    val props = new util.HashMap[String, String]()
+    props.put(IotHubSourceConfig.EventHubCompatibleName, iotHubName)
+    props.put(IotHubSourceConfig.EventHubCompatibleNamespace, iotHubNamespace)
+    props.put(IotHubSourceConfig.IotHubAccessKeyName, iotHubKeyName)
+    props.put(IotHubSourceConfig.IotHubAccessKeyValue, iotHubKeyValue)
+    props.put(IotHubSourceConfig.IotHubPartitions, iotHubPartitions.toString)
+    props.put(IotHubSourceConfig.KafkaTopic, "test")
+    props.put(IotHubSourceConfig.IotHubStartTime, "2016-12-10T00:00:00Z")
     props
   }
 

--- a/src/test/scala/com/microsoft/azure/iot/iothub2kafka/testhelpers/TestIotHubSourceTask.scala
+++ b/src/test/scala/com/microsoft/azure/iot/iothub2kafka/testhelpers/TestIotHubSourceTask.scala
@@ -9,6 +9,6 @@ import com.microsoft.azure.iot.kafka.connect.{DataReceiver, IotHubSourceTask}
 class TestIotHubSourceTask extends IotHubSourceTask {
   override def getDataReceiver(connectionString: String, receiverConsumerGroup: String, partition: String,
                                partitionOffset: Option[String], partitionStartTime: Option[Instant]): DataReceiver = {
-    new MockDataReceiver
+    new MockDataReceiver(connectionString, receiverConsumerGroup, partition, partitionOffset, partitionStartTime)
   }
 }


### PR DESCRIPTION
- Updated the schema of the IotMessage so that the system properties
are structured into the source record being sent to the Kafka Connector.
- Changed exceptions thrown from IotHub to be ConnectExceptions to give
correct behavior in Kafka Connect
- Added additional tests for schema changes and also to show usage of
StartTime for the connector