### PR TITLE
updates dependency to Azure SDKs and Kafka API

### DIFF
--- a/README_Sink.md
+++ b/README_Sink.md
@@ -100,7 +100,7 @@ these types in Kafka topics.
 Kafka Connect is a generic tool to copy data between Kafka and other systems (like Azure IoT Hub). To copy data from
 Azure IoT Hub to Kafka, you need to make the code from this repository available to Kafka Connect and configure it to
 use the right Azure IoT Hub and Kafka settings. For more details on using Kafka Connect, you can refer to the
-[Kafka Connect user guide](http://docs.confluent.io/3.0.0/connect/userguide.html).
+[Kafka Connect user guide](http://docs.confluent.io/3.2.2/connect/userguide.html).
 
 #### Pre-requisites
 
@@ -108,23 +108,23 @@ use the right Azure IoT Hub and Kafka settings. For more details on using Kafka 
 [here](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-java-java-getstarted).
 
 * You also need to have Apache Kafka v0.10 installation running, that contains messages to be sent to the IoT devices in
- one or more topics. Get started with Kafka [here](http://docs.confluent.io/3.0.0/quickstart.html).
+ one or more topics. Get started with Kafka [here](http://docs.confluent.io/3.2.2/quickstart.html).
 
 #### Steps
 
 Here are the steps to run the Kafka Connect IoT Hub Sink Connector in
-[standalone mode](http://docs.confluent.io/3.0.0/connect/userguide.html#standalone-worker-configuration). For
-[distributed mode](http://docs.confluent.io/3.0.0/connect/userguide.html#distributed-worker-configuration), the
+[standalone mode](http://docs.confluent.io/3.2.2/connect/userguide.html#standalone-worker-configuration). For
+[distributed mode](http://docs.confluent.io/3.2.2/connect/userguide.html#distributed-worker-configuration), the
 connector configuration will stay the same.
 
 The steps to insert messages in Kafka topics and to run the Sink connector depend on whether you are using the
-[Schema Registry](http://docs.confluent.io/3.0.0/schema-registry/docs/) along with the Confluent platform. So please
+[Schema Registry](http://docs.confluent.io/3.2.2/schema-registry/docs/) along with the Confluent platform. So please
 follow the right set of steps below depending on your choice.
 
 ##### Steps when using Schema Registry
 
-When using [Schema Registry](http://docs.confluent.io/3.0.0/schema-registry/docs/) along with the
-[Confluent Platform](http://docs.confluent.io/3.0.0/platform.html), messages are inserted in Kafka topic as Avro records
+When using [Schema Registry](http://docs.confluent.io/3.2.2/schema-registry/docs/) along with the
+[Confluent Platform](http://docs.confluent.io/3.2.2/platform.html), messages are inserted in Kafka topic as Avro records
  which include the schema of the messages.
 
  1. Build the source code after cloning this repository using the following command, which will generate a jar file with
@@ -150,10 +150,10 @@ When using [Schema Registry](http://docs.confluent.io/3.0.0/schema-registry/docs
  ```
 
  5. Make sure Kafka server, Zookeeper, and Schema Registry are running, as described
- [here](http://docs.confluent.io/3.0.0/quickstart.html)
+ [here](http://docs.confluent.io/3.2.2/quickstart.html)
 
  6. Start Kafka source connector in
- [standalone mode](http://docs.confluent.io/3.0.0/connect/userguide.html#standalone-worker-configuration) to read
+ [standalone mode](http://docs.confluent.io/3.2.2/connect/userguide.html#standalone-worker-configuration) to read
  messages from Kafka topic and send them to the IoT Devices -
 
  ```
@@ -161,7 +161,7 @@ When using [Schema Registry](http://docs.confluent.io/3.0.0/schema-registry/docs
  ```
 
 7. Insert messages to be sent to the IoT devices in the Kafka topic as Avro records. One way you can do that is using a
-[KafkaProducer](http://docs.confluent.io/3.0.0/clients/producer.html). Here is some sample code to send such messages to
+[KafkaProducer](http://docs.confluent.io/3.2.2/clients/producer.html). Here is some sample code to send such messages to
  a Kafka topic in the right format.
 
 ```java
@@ -224,7 +224,7 @@ consumer.max.poll.records=10
 5. Make sure Kafka server and Zookeeper are running, as described [here](https://kafka.apache.org/documentation#quickstart)
 
 6. Start Kafka source connector in
-[standalone mode](http://docs.confluent.io/3.0.0/connect/userguide.html#standalone-worker-configuration) to read
+[standalone mode](http://docs.confluent.io/3.2.2/connect/userguide.html#standalone-worker-configuration) to read
 messages from Kafka topic and send them to the IoT Devices -
 
 ```

--- a/README_Source.md
+++ b/README_Source.md
@@ -36,7 +36,7 @@ the beginning.
 Here is a sample connect-iothub-source.properties file. (Some of these values are not configurable, and hence omitted
   from the list above)
 ```
-connector.class=com.microsoft.azure.iot.kafka.connect.IotHubSourceConnector
+connector.class=com.microsoft.azure.iot.kafka.connect.source.IotHubSourceConnector
 name=AzureIotHubConnector
 tasks.max=1
 Kafka.Topic=IotTopic

--- a/build.sbt
+++ b/build.sbt
@@ -12,14 +12,14 @@ scalacOptions ++= Seq("-deprecation", "-explaintypes", "-unchecked", "-feature")
 
 libraryDependencies ++= {
 
-  val kafkaVersion = "0.10.0.1"
-  val azureEventHubSDKVersion = "0.9.0"
+  val kafkaVersion = "0.10.2.1"
+  val azureEventHubSDKVersion = "0.14.0"
   val scalaLoggingVersion = "3.5.0"
   val logbackClassicVersion = "1.1.7"
   val scalaTestVersion = "3.0.0"
   val configVersion = "1.3.1"
   val json4sVersion = "3.5.0"
-  val iotHubServiceClientVersion = "1.0.12"
+  val iotHubServiceClientVersion = "1.4.22"
 
   Seq(
     "org.apache.kafka" % "connect-api" % kafkaVersion % "provided",

--- a/src/main/scala/com/microsoft/azure/iot/kafka/connect/sink/C2DMessageConverter.scala
+++ b/src/main/scala/com/microsoft/azure/iot/kafka/connect/sink/C2DMessageConverter.scala
@@ -7,7 +7,7 @@ package com.microsoft.azure.iot.kafka.connect.sink
 import java.time.Instant
 import java.util.Date
 
-import com.microsoft.azure.iot.kafka.connect.JsonSerialization
+import com.microsoft.azure.iot.kafka.connect.source.JsonSerialization
 import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
 import org.apache.kafka.connect.errors.ConnectException
 import org.apache.kafka.connect.sink.SinkRecord

--- a/src/main/scala/com/microsoft/azure/iot/kafka/connect/sink/IotHubMessageSender.scala
+++ b/src/main/scala/com/microsoft/azure/iot/kafka/connect/sink/IotHubMessageSender.scala
@@ -4,7 +4,7 @@
 
 package com.microsoft.azure.iot.kafka.connect.sink
 
-import com.microsoft.azure.sdk.iot.service.sdk.{IotHubServiceClientProtocol, Message, ServiceClient}
+import com.microsoft.azure.sdk.iot.service.{IotHubServiceClientProtocol, Message, ServiceClient}
 
 class IotHubMessageSender(connectionString: String) extends MessageSender {
 

--- a/src/main/scala/com/microsoft/azure/iot/kafka/connect/sink/IotHubSinkConfig.scala
+++ b/src/main/scala/com/microsoft/azure/iot/kafka/connect/sink/IotHubSinkConfig.scala
@@ -6,7 +6,7 @@ package com.microsoft.azure.iot.kafka.connect.sink
 
 import java.util.Map
 
-import com.microsoft.azure.sdk.iot.service.sdk.DeliveryAcknowledgement
+import com.microsoft.azure.sdk.iot.service.DeliveryAcknowledgement
 import org.apache.kafka.common.config.ConfigDef.{Importance, Type, Width}
 import org.apache.kafka.common.config.{AbstractConfig, ConfigDef}
 

--- a/src/main/scala/com/microsoft/azure/iot/kafka/connect/sink/IotHubSinkConnector.scala
+++ b/src/main/scala/com/microsoft/azure/iot/kafka/connect/sink/IotHubSinkConnector.scala
@@ -6,7 +6,7 @@ package com.microsoft.azure.iot.kafka.connect.sink
 
 import java.util
 
-import com.microsoft.azure.iot.kafka.connect.JsonSerialization
+import com.microsoft.azure.iot.kafka.connect.source.JsonSerialization
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.kafka.common.config.{ConfigDef, ConfigException}
 import org.apache.kafka.connect.connector.Task
@@ -22,7 +22,7 @@ class IotHubSinkConnector extends SinkConnector with LazyLogging with JsonSerial
   override def taskClass(): Class[_ <: Task] = classOf[IotHubSinkTask]
 
   override def taskConfigs(maxTasks: Int): util.List[util.Map[String, String]] = {
-    (1 to maxTasks).map(c => this.props.asJava).toList.asJava
+    (1 to maxTasks).map(_ => this.props.asJava).toList.asJava
   }
 
   override def stop(): Unit = {

--- a/src/main/scala/com/microsoft/azure/iot/kafka/connect/sink/IotHubSinkTask.scala
+++ b/src/main/scala/com/microsoft/azure/iot/kafka/connect/sink/IotHubSinkTask.scala
@@ -6,8 +6,8 @@ package com.microsoft.azure.iot.kafka.connect.sink
 
 import java.util
 
-import com.microsoft.azure.iot.kafka.connect.JsonSerialization
-import com.microsoft.azure.sdk.iot.service.sdk.{DeliveryAcknowledgement, Message}
+import com.microsoft.azure.iot.kafka.connect.source.JsonSerialization
+import com.microsoft.azure.sdk.iot.service.{DeliveryAcknowledgement, Message}
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
@@ -54,7 +54,7 @@ class IotHubSinkTask extends SinkTask with LazyLogging with JsonSerialization {
   }
 
   private def sendMessage(c2DMessage: C2DMessage): Unit = {
-    logger.debug(s"Sending c2d message ${c2DMessage.toString}")
+    logger.info(s"Sending c2d message ${c2DMessage.toString}")
     val message = new Message(c2DMessage.message)
     message.setMessageId(c2DMessage.messageId)
     message.setDeliveryAcknowledgement(acknowledgement)

--- a/src/main/scala/com/microsoft/azure/iot/kafka/connect/sink/MessageSender.scala
+++ b/src/main/scala/com/microsoft/azure/iot/kafka/connect/sink/MessageSender.scala
@@ -4,7 +4,7 @@
 
 package com.microsoft.azure.iot.kafka.connect.sink
 
-import com.microsoft.azure.sdk.iot.service.sdk.Message
+import com.microsoft.azure.sdk.iot.service.Message
 
 trait MessageSender {
   def sendMessage(deviceId: String, message: Message)

--- a/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/DataReceiver.scala
+++ b/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/DataReceiver.scala
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-package com.microsoft.azure.iot.kafka.connect
+package com.microsoft.azure.iot.kafka.connect.source
 
 trait DataReceiver {
   def receiveData(batchSize: Int): Iterable[IotMessage]

--- a/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/EventHubReceiver.scala
+++ b/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/EventHubReceiver.scala
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-package com.microsoft.azure.iot.kafka.connect
+package com.microsoft.azure.iot.kafka.connect.source
 
 import java.time.Instant
 
@@ -32,7 +32,7 @@ class EventHubReceiver(val connectionString: String, val receiverConsumerGroup: 
     if (this.eventHubReceiver != null) {
       this.eventHubReceiver.synchronized {
         this.isClosing = true
-        (eventHubReceiver.close()).join()
+        eventHubReceiver.close().join()
       }
     }
   }
@@ -50,7 +50,7 @@ class EventHubReceiver(val connectionString: String, val receiverConsumerGroup: 
             if (batch != null) {
               val batchIterable = batch.asScala
               iotMessages ++= batchIterable.map(e => {
-                val content = new String(e.getBody)
+                val content = new String(e.getBytes)
                 val iotDeviceData = IotMessage(content, e.getSystemProperties.asScala, e.getProperties.asScala)
                 iotDeviceData
               })

--- a/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubPartitionSource.scala
+++ b/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubPartitionSource.scala
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-package com.microsoft.azure.iot.kafka.connect
+package com.microsoft.azure.iot.kafka.connect.source
 
 import java.util.{Collections, Map}
 

--- a/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceConfig.scala
+++ b/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceConfig.scala
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-package com.microsoft.azure.iot.kafka.connect
+package com.microsoft.azure.iot.kafka.connect.source
 
 import com.microsoft.azure.eventhubs.EventHubClient
 import org.apache.kafka.common.config.ConfigDef.{Importance, Type, Width}

--- a/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceConnector.scala
+++ b/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceConnector.scala
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-package com.microsoft.azure.iot.kafka.connect
+package com.microsoft.azure.iot.kafka.connect.source
 
 import java.util
 

--- a/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceTask.scala
+++ b/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceTask.scala
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-package com.microsoft.azure.iot.kafka.connect
+package com.microsoft.azure.iot.kafka.connect.source
 
 import java.time.Instant
 import java.util

--- a/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotMessage.scala
+++ b/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotMessage.scala
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-package com.microsoft.azure.iot.kafka.connect
+package com.microsoft.azure.iot.kafka.connect.source
 
 case class IotMessage(content: String, systemProperties: scala.collection.mutable.Map[String, Object],
-    properties: scala.collection.mutable.Map[String, String])
+    properties: scala.collection.mutable.Map[String, Object])

--- a/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotMessageConverter.scala
+++ b/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotMessageConverter.scala
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-package com.microsoft.azure.iot.kafka.connect
+package com.microsoft.azure.iot.kafka.connect.source
 
 import java.time.Instant
 import java.util.Date

--- a/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/JsonSerialization.scala
+++ b/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/JsonSerialization.scala
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-package com.microsoft.azure.iot.kafka.connect
+package com.microsoft.azure.iot.kafka.connect.source
 
 import org.json4s.DefaultFormats
 

--- a/src/test/scala/com/microsoft/azure/iot/kafka/connect/sink/C2DMessageConverterTest.scala
+++ b/src/test/scala/com/microsoft/azure/iot/kafka/connect/sink/C2DMessageConverterTest.scala
@@ -7,8 +7,8 @@ package com.microsoft.azure.iot.kafka.connect.sink
 import java.time.Instant
 import java.util.Date
 
-import com.microsoft.azure.iot.kafka.connect.JsonSerialization
 import com.microsoft.azure.iot.kafka.connect.sink.testhelpers.{TestSchemas, TestSinkRecords}
+import com.microsoft.azure.iot.kafka.connect.source.JsonSerialization
 import org.apache.kafka.connect.errors.ConnectException
 import org.scalatest.{FlatSpec, GivenWhenThen}
 

--- a/src/test/scala/com/microsoft/azure/iot/kafka/connect/sink/IotHubSinkConnectorTest.scala
+++ b/src/test/scala/com/microsoft/azure/iot/kafka/connect/sink/IotHubSinkConnectorTest.scala
@@ -4,7 +4,7 @@
 
 package com.microsoft.azure.iot.kafka.connect.sink
 
-import com.microsoft.azure.iot.kafka.connect.JsonSerialization
+import com.microsoft.azure.iot.kafka.connect.source.JsonSerialization
 import com.microsoft.azure.iot.kafka.connect.sink.testhelpers.SinkTestConfig
 import org.apache.kafka.connect.errors.ConnectException
 import org.scalatest.{FlatSpec, GivenWhenThen}

--- a/src/test/scala/com/microsoft/azure/iot/kafka/connect/sink/IotHubSinkTaskTest.scala
+++ b/src/test/scala/com/microsoft/azure/iot/kafka/connect/sink/IotHubSinkTaskTest.scala
@@ -6,9 +6,9 @@ package com.microsoft.azure.iot.kafka.connect.sink
 
 import java.util.function._
 
-import com.microsoft.azure.iot.kafka.connect.JsonSerialization
+import com.microsoft.azure.iot.kafka.connect.source.JsonSerialization
 import com.microsoft.azure.iot.kafka.connect.sink.testhelpers.{SinkTestConfig, TestIotHubSinkTask, TestSinkRecords}
-import com.microsoft.azure.sdk.iot.service.sdk.DeliveryAcknowledgement
+import com.microsoft.azure.sdk.iot.service.DeliveryAcknowledgement
 import org.apache.kafka.connect.data.Struct
 import org.apache.kafka.connect.errors.ConnectException
 import org.apache.kafka.connect.sink.SinkRecord

--- a/src/test/scala/com/microsoft/azure/iot/kafka/connect/sink/testhelpers/MockMessageSender.scala
+++ b/src/test/scala/com/microsoft/azure/iot/kafka/connect/sink/testhelpers/MockMessageSender.scala
@@ -5,7 +5,7 @@
 package com.microsoft.azure.iot.kafka.connect.sink.testhelpers
 
 import com.microsoft.azure.iot.kafka.connect.sink.MessageSender
-import com.microsoft.azure.sdk.iot.service.sdk.Message
+import com.microsoft.azure.sdk.iot.service.Message
 
 import scala.collection.mutable.ArrayBuffer
 

--- a/src/test/scala/com/microsoft/azure/iot/kafka/connect/sink/testhelpers/SinkTestConfig.scala
+++ b/src/test/scala/com/microsoft/azure/iot/kafka/connect/sink/testhelpers/SinkTestConfig.scala
@@ -7,7 +7,7 @@ package com.microsoft.azure.iot.kafka.connect.sink.testhelpers
 import java.util
 
 import com.microsoft.azure.iot.kafka.connect.sink.IotHubSinkConfig
-import com.microsoft.azure.sdk.iot.service.sdk.DeliveryAcknowledgement
+import com.microsoft.azure.sdk.iot.service.DeliveryAcknowledgement
 import com.typesafe.config.ConfigFactory
 
 object SinkTestConfig {

--- a/src/test/scala/com/microsoft/azure/iot/kafka/connect/sink/testhelpers/TestIotHubSinkTask.scala
+++ b/src/test/scala/com/microsoft/azure/iot/kafka/connect/sink/testhelpers/TestIotHubSinkTask.scala
@@ -5,7 +5,7 @@
 package com.microsoft.azure.iot.kafka.connect.sink.testhelpers
 
 import com.microsoft.azure.iot.kafka.connect.sink.{IotHubSinkTask, MessageSender}
-import com.microsoft.azure.sdk.iot.service.sdk.{DeliveryAcknowledgement, Message}
+import com.microsoft.azure.sdk.iot.service.{DeliveryAcknowledgement, Message}
 
 import scala.collection.mutable.ArrayBuffer
 

--- a/src/test/scala/com/microsoft/azure/iot/kafka/connect/sink/testhelpers/TestSinkModels.scala
+++ b/src/test/scala/com/microsoft/azure/iot/kafka/connect/sink/testhelpers/TestSinkModels.scala
@@ -8,7 +8,7 @@ import java.time.Instant
 import java.util
 import java.util.Date
 
-import com.microsoft.azure.iot.kafka.connect.JsonSerialization
+import com.microsoft.azure.iot.kafka.connect.source.JsonSerialization
 import com.microsoft.azure.iot.kafka.connect.sink.C2DMessage
 import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
 import org.apache.kafka.connect.sink.SinkRecord

--- a/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceConnectorTest.scala
+++ b/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceConnectorTest.scala
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-package com.microsoft.azure.iot.kafka.connect
+package com.microsoft.azure.iot.kafka.connect.source
 
 import java.time.Instant
 
-import com.microsoft.azure.iot.kafka.connect.testhelpers.TestConfig
+import com.microsoft.azure.iot.kafka.connect.source.testhelpers.TestConfig
 import org.apache.kafka.connect.errors.ConnectException
 import org.json4s.jackson.Serialization.read
 import org.scalatest.{FlatSpec, GivenWhenThen}

--- a/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceTaskTest.scala
+++ b/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceTaskTest.scala
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-package com.microsoft.azure.iot.kafka.connect
+package com.microsoft.azure.iot.kafka.connect.source
 
 import java.time.Instant
 import java.util
 
-import com.microsoft.azure.iot.kafka.connect.testhelpers.{DeviceTemperature, MockDataReceiver, TestConfig, TestIotHubSourceTask}
+import com.microsoft.azure.iot.kafka.connect.source.testhelpers.{DeviceTemperature, MockDataReceiver, TestConfig, TestIotHubSourceTask}
 import org.apache.kafka.connect.data.Struct
 import org.json4s.jackson.Serialization.read
 import org.scalatest.{FlatSpec, GivenWhenThen}

--- a/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/IotMessageConverterTest.scala
+++ b/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/IotMessageConverterTest.scala
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-package com.microsoft.azure.iot.kafka.connect
+package com.microsoft.azure.iot.kafka.connect.source
 
 import java.text.SimpleDateFormat
 import java.time.Instant
 
-import com.microsoft.azure.iot.kafka.connect.testhelpers.DeviceTemperature
+import com.microsoft.azure.iot.kafka.connect.source.testhelpers.DeviceTemperature
 import com.microsoft.azure.servicebus.amqp.AmqpConstants
 import org.apache.kafka.connect.data.Struct
 import org.json4s.jackson.Serialization._
@@ -36,7 +36,7 @@ class IotMessageConverterTest extends FlatSpec with GivenWhenThen with JsonSeria
       AmqpConstants.ENQUEUED_TIME_UTC_ANNOTATION_NAME → enqueuedDate)
 
     val timestamp = Instant.now().toString
-    val messageProperties = mutable.Map[String, String](
+    val messageProperties = mutable.Map[String, Object](
       "timestamp" → timestamp,
       "contentType" → "temperature"
     )
@@ -71,7 +71,7 @@ class IotMessageConverterTest extends FlatSpec with GivenWhenThen with JsonSeria
     val deviceTempStr = write(deviceTemp)
 
     val systemProperties = mutable.Map.empty[String, Object]
-    val messageProperties = mutable.Map.empty[String, String]
+    val messageProperties = mutable.Map.empty[String, Object]
 
     val iotMessage = IotMessage(deviceTempStr, systemProperties, messageProperties)
 

--- a/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/testhelpers/DeviceTemperature.scala
+++ b/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/testhelpers/DeviceTemperature.scala
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-package com.microsoft.azure.iot.kafka.connect.testhelpers
+package com.microsoft.azure.iot.kafka.connect.source.testhelpers
 
 case class DeviceTemperature (var value : Double, val unit : String)

--- a/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/testhelpers/MockDataReceiver.scala
+++ b/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/testhelpers/MockDataReceiver.scala
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-package com.microsoft.azure.iot.kafka.connect.testhelpers
+package com.microsoft.azure.iot.kafka.connect.source.testhelpers
 
 import java.text.SimpleDateFormat
 import java.time.{Duration, Instant}
 
-import com.microsoft.azure.iot.kafka.connect.{DataReceiver, IotMessage, JsonSerialization}
+import com.microsoft.azure.iot.kafka.connect.source.{DataReceiver, IotMessage, JsonSerialization}
 import com.microsoft.azure.servicebus.amqp.AmqpConstants
 import org.json4s.jackson.Serialization.write
 
@@ -37,7 +37,7 @@ class MockDataReceiver(val connectionString: String, val receiverConsumerGroup: 
       AmqpConstants.OFFSET_ANNOTATION_NAME → random.nextString(10),
       AmqpConstants.ENQUEUED_TIME_UTC_ANNOTATION_NAME → new SimpleDateFormat("MM/dd/yyyy").parse("12/01/2016"))
 
-    val messageProperties = mutable.Map[String, String](
+    val messageProperties = mutable.Map[String, Object](
       "timestamp" → Instant.now().toString,
       "contentType" → "temperature"
     )

--- a/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/testhelpers/TestConfig.scala
+++ b/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/testhelpers/TestConfig.scala
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-package com.microsoft.azure.iot.kafka.connect.testhelpers
+package com.microsoft.azure.iot.kafka.connect.source.testhelpers
 
 import java.util
 
-import com.microsoft.azure.iot.kafka.connect.IotHubSourceConfig
+import com.microsoft.azure.iot.kafka.connect.source.IotHubSourceConfig
 import com.microsoft.azure.servicebus.ConnectionStringBuilder
 import com.typesafe.config.ConfigFactory
 

--- a/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/testhelpers/TestIotHubSourceTask.scala
+++ b/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/testhelpers/TestIotHubSourceTask.scala
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-package com.microsoft.azure.iot.kafka.connect.testhelpers
+package com.microsoft.azure.iot.kafka.connect.source.testhelpers
 
 import java.time.Instant
 
-import com.microsoft.azure.iot.kafka.connect.{DataReceiver, IotHubSourceTask}
+import com.microsoft.azure.iot.kafka.connect.source.{DataReceiver, IotHubSourceTask}
 
 class TestIotHubSourceTask extends IotHubSourceTask {
   override def getDataReceiver(connectionString: String, receiverConsumerGroup: String, partition: String,


### PR DESCRIPTION
Hi, 

While experimenting with this kafka Connect connector, I noted that some libraries could be updated

=> I updated the sbt build as follows

 - updated Azure SDK IOT from 1.0.12 to 1.4.22
 - updated Azure Event Hub SDK lib from 0.9.0 to 0.14.0
 - updated kafka API from 0.10.0.1 to  0.10.2.1

Also: since it seems that some SDK classes have been moved, I updated the packages name to align on that. 

All UT still pass and I also tested it successfully to forward messages from my local Kafka cluster to my IoTHub instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/toketi-kafka-connect-iothub/7)
<!-- Reviewable:end -->
