### PR TITLE
Fixing connector.class entry to match actual class name

### DIFF
--- a/connect-iothub-source.properties
+++ b/connect-iothub-source.properties
@@ -1,7 +1,7 @@
 ############################# Connector Config #############################
 # Identifies the Azure IoT Hub source connector.
 # Do not change this if you want to use the Azure IotHub source connector
-connector.class=com.microsoft.azure.iot.kafka.connect.IotHubSourceConnector
+connector.class=com.microsoft.azure.iot.kafka.connect.source.IotHubSourceConnector
 
 # Name of the connector
 name=AzureIotHubConnector


### PR DESCRIPTION
When building a copy of this, and trying to use the source, I noticed that the connector.class in the connect-iothub-source.properties doesn't match the actual class name. This causes errors when starting the connector.

Simple fix included.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/toketi-kafka-connect-iothub/9)
<!-- Reviewable:end -->
