### PR TITLE
Receive timeout

### DIFF
--- a/README_Source.md
+++ b/README_Source.md
@@ -28,6 +28,7 @@ Here are the configurable values -
 | IotHub.StartTime | String | No | (Unused if not supplied) | The time from which to start retrieving messages from IoT Hub. The value should be in UTC and in the format yyyy-mm-ddThh:mm:ssZ. This setting is mutually exclusive with IotHub.Offsets. |
 | IotHub.Offsets | String | No | (Unused if not supplied) | The offsets for each IoT Hub partition from which to start retrieving messages from IoTHub, as a comma separated string. For example, for 4 partitions, the value would be something like "abc,lmn,pqr,xyz". This setting is mutually exclusive with IotHub.StartTime. |
 | BatchSize | Int | No | 100 | The size of each batch for retrieving entries from IoT Hub. |
+| RequestTimeout | Int | No | 60 | The max duration in seconds to spend receiving entries from IoT Hub. |
 
 > Note: If IotHub.StartTime is specified, then the value for IotHub.Offsets is ignored.
 > If neither IotHub.StartTime not IotHub.Offsets are specified, then the messages are retrieved from the IoT Hub from
@@ -49,6 +50,7 @@ IotHub.Partitions=4
 IotHub.StartTime=2016-11-28T00:00:00Z
 IotHub.Offsets=
 BatchSize=100
+RequestTimeout=60
 ```
 
 ### Building and running

--- a/README_Source.md
+++ b/README_Source.md
@@ -27,8 +27,8 @@ Here are the configurable values -
 | IotHub.Partitions | String | Yes |  | The access key for the IoT Hub. In the Azure Portal, navigate to "IoT Hub" >> your hub >> "Endpoints" >> "Events" >> "Partitions". |
 | IotHub.StartTime | String | No | (Unused if not supplied) | The time from which to start retrieving messages from IoT Hub. The value should be in UTC and in the format yyyy-mm-ddThh:mm:ssZ. This setting is mutually exclusive with IotHub.Offsets. |
 | IotHub.Offsets | String | No | (Unused if not supplied) | The offsets for each IoT Hub partition from which to start retrieving messages from IoTHub, as a comma separated string. For example, for 4 partitions, the value would be something like "abc,lmn,pqr,xyz". This setting is mutually exclusive with IotHub.StartTime. |
-| BatchSize | Int | No | 100 | The size of each batch for retrieving entries from IoT Hub. |
-| RequestTimeout | Int | No | 60 | The max duration in seconds to spend receiving entries from IoT Hub. |
+| BatchSize | Int | No | 100 | The size of each batch for retrieving messages from IoT Hub. |
+| ReceiveTimeout | Int | No | 60 | The max duration in seconds to wait for a full batch when retrieving messages from IoT Hub. |
 
 > Note: If IotHub.StartTime is specified, then the value for IotHub.Offsets is ignored.
 > If neither IotHub.StartTime not IotHub.Offsets are specified, then the messages are retrieved from the IoT Hub from
@@ -50,7 +50,7 @@ IotHub.Partitions=4
 IotHub.StartTime=2016-11-28T00:00:00Z
 IotHub.Offsets=
 BatchSize=100
-RequestTimeout=60
+ReceiveTimeout=60
 ```
 
 ### Building and running

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-val iotHubKafkaConnectVersion = "0.6"
+val iotHubKafkaConnectVersion = "0.6.1"
 
 name := "kafka-connect-iothub"
 organization := "com.microsoft.azure.iot"

--- a/connect-iothub-source.properties
+++ b/connect-iothub-source.properties
@@ -54,8 +54,8 @@ IotHub.StartTime=PLACEHOLDER
 # If StartTime is provided, the Offsets value will be ignored.
 IotHub.Offsets=PLACEHOLDER
 
-# The size of each batch for retrieving entries from IoTHub. The max supported value is 999.
+# The size of each batch for retrieving messages from IoTHub. The max supported value is 999.
 BatchSize=100
 
-# The max duration in seconds to spend receiving entries from IoTHub. The default is 60.
+# The max duration in seconds to wait for a full batch when retrieving messages from IoTHub. The default is 60.
 ReceiveTimeout=60

--- a/connect-iothub-source.properties
+++ b/connect-iothub-source.properties
@@ -56,3 +56,6 @@ IotHub.Offsets=PLACEHOLDER
 
 # The size of each batch for retrieving entries from IoTHub. The max supported value is 999.
 BatchSize=100
+
+# The max duration in seconds to spend receiving entries from IoTHub. The default is 60.
+ReceiveTimeout=60

--- a/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/EventHubReceiver.scala
+++ b/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/EventHubReceiver.scala
@@ -2,7 +2,7 @@
 
 package com.microsoft.azure.iot.kafka.connect.source
 
-import java.time.Instant
+import java.time.{Duration, Instant}
 
 import com.microsoft.azure.eventhubs.{EventHubClient, PartitionReceiver}
 
@@ -10,7 +10,7 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 
 class EventHubReceiver(val connectionString: String, val receiverConsumerGroup: String, val partition: String,
-    var offset: Option[String], val startTime: Option[Instant]) extends DataReceiver {
+    var offset: Option[String], val startTime: Option[Instant], val receiveTimeout: Duration) extends DataReceiver {
 
   private[this] var isClosing = false
 
@@ -27,6 +27,7 @@ class EventHubReceiver(val connectionString: String, val receiverConsumerGroup: 
   if (this.eventHubReceiver == null) {
     throw new IllegalArgumentException("Unable to create PartitionReceiver from the input parameters.")
   }
+  this.eventHubReceiver.setReceiveTimeout(receiveTimeout)
 
   override def close(): Unit = {
     if (this.eventHubReceiver != null) {

--- a/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceConfig.scala
+++ b/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceConfig.scala
@@ -11,6 +11,7 @@ import java.util.Map
 object IotHubSourceConfig {
 
   private val defaultBatchSize = 100
+  private val defaultReceiveTimeout = 60
   private val iotConfigGroup   = "Azure IoT Hub"
   private val kafkaConfig      = "Kafka"
 
@@ -36,6 +37,8 @@ object IotHubSourceConfig {
   val KafkaTopicDoc                      = "Kafka topic to copy data to"
   val BatchSize                          = "BatchSize"
   val BatchSizeDoc                       = "The batch size for fetching records from IoT Hub"
+  val ReceiveTimeout                     = "ReceiveTimeout"
+  val ReceiveTimeoutDoc                  = "Max time to spend receiving messages from IoT Hub"
   val IotHubOffset                       = "IotHub.Offsets"
   val IotHubOffsetDoc                    =
     "Offset for each partition in IotHub, as a comma separated string. This value is ignored if IotHubStartTime is specified."
@@ -63,7 +66,9 @@ object IotHubSourceConfig {
       "Per partition offsets")
     .define(BatchSize, Type.INT, defaultBatchSize, Importance.MEDIUM, IotHubOffsetDoc, iotConfigGroup, 9, Width.SHORT,
       "Batch size")
-    .define(KafkaTopic, Type.STRING, Importance.HIGH, KafkaTopicDoc, kafkaConfig, 10, Width.MEDIUM, "Kafka topic")
+    .define(ReceiveTimeout, Type.INT, defaultReceiveTimeout, Importance.MEDIUM, ReceiveTimeoutDoc, iotConfigGroup, 10,
+      Width.SHORT, "Receive Timeout")
+    .define(KafkaTopic, Type.STRING, Importance.HIGH, KafkaTopicDoc, kafkaConfig, 11, Width.MEDIUM, "Kafka topic")
 
   def getConfig(configValues: Map[String, String]): IotHubSourceConfig = {
     new IotHubSourceConfig(configDef, configValues)

--- a/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceConnector.scala
+++ b/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceConnector.scala
@@ -92,6 +92,7 @@ class IotHubSourceConnector extends SourceConnector with LazyLogging with JsonSe
       IotHubSourceConfig.EventHubCompatibleConnectionString -> iotHubConnectionString,
       IotHubSourceConfig.IotHubOffset -> iotHubSourceConfig.getString(IotHubSourceConfig.IotHubOffset),
       IotHubSourceConfig.BatchSize -> iotHubSourceConfig.getInt(IotHubSourceConfig.BatchSize).toString,
+      IotHubSourceConfig.ReceiveTimeout -> iotHubSourceConfig.getInt(IotHubSourceConfig.ReceiveTimeout).toString,
       IotHubSourceConfig.KafkaTopic -> iotHubSourceConfig.getString(IotHubSourceConfig.KafkaTopic),
       IotHubSourceConfig.IotHubConsumerGroup -> iotHubSourceConfig.getString(IotHubSourceConfig.IotHubConsumerGroup),
       IotHubSourceConfig.IotHubPartitions -> iotHubSourceConfig.getInt(IotHubSourceConfig.IotHubPartitions).toString,

--- a/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceConnectorTest.scala
+++ b/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceConnectorTest.scala
@@ -28,10 +28,12 @@ class IotHubSourceConnectorTest extends FlatSpec with GivenWhenThen with JsonSer
       assert(taskConfig.containsKey(IotHubSourceConfig.IotHubConsumerGroup))
       assert(taskConfig.containsKey(IotHubSourceConfig.KafkaTopic))
       assert(taskConfig.containsKey(IotHubSourceConfig.BatchSize))
+      assert(taskConfig.containsKey(IotHubSourceConfig.ReceiveTimeout))
       assert(taskConfig.containsKey(IotHubSourceConfig.TaskPartitionOffsetsMap))
 
       assert(taskConfig.get(IotHubSourceConfig.EventHubCompatibleConnectionString) != "")
       assert(taskConfig.get(IotHubSourceConfig.BatchSize) == "100")
+      assert(taskConfig.get(IotHubSourceConfig.ReceiveTimeout) == "45")
       assert(taskConfig.get(IotHubSourceConfig.IotHubOffset) == "-1,5,10,15,-1")
     }
 
@@ -70,10 +72,12 @@ class IotHubSourceConnectorTest extends FlatSpec with GivenWhenThen with JsonSer
       assert(taskConfig.containsKey(IotHubSourceConfig.IotHubConsumerGroup))
       assert(taskConfig.containsKey(IotHubSourceConfig.KafkaTopic))
       assert(taskConfig.containsKey(IotHubSourceConfig.BatchSize))
+      assert(taskConfig.containsKey(IotHubSourceConfig.ReceiveTimeout))
       assert(taskConfig.containsKey(IotHubSourceConfig.TaskPartitionOffsetsMap))
 
       assert(taskConfig.get(IotHubSourceConfig.EventHubCompatibleConnectionString) != "")
       assert(taskConfig.get(IotHubSourceConfig.BatchSize) == "100")
+      assert(taskConfig.get(IotHubSourceConfig.ReceiveTimeout) == "60")
       assert(taskConfig.get(IotHubSourceConfig.IotHubOffset) == "")
       assert(taskConfig.get(IotHubSourceConfig.IotHubStartTime) == "2016-12-10T00:00:00Z")
     }

--- a/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceTaskTest.scala
+++ b/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceTaskTest.scala
@@ -2,7 +2,7 @@
 
 package com.microsoft.azure.iot.kafka.connect.source
 
-import java.time.Instant
+import java.time.{Duration, Instant}
 import java.util
 
 import com.microsoft.azure.iot.kafka.connect.source.testhelpers.{DeviceTemperature, MockDataReceiver, TestConfig, TestIotHubSourceTask}
@@ -69,6 +69,7 @@ class IotHubSourceTaskTest extends FlatSpec with GivenWhenThen with JsonSerializ
       assert(dataReceiver.startTime.isEmpty)
       assert(dataReceiver.connectionString != "")
       assert(dataReceiver.receiverConsumerGroup != "")
+      assert(dataReceiver.receiveTimeout == Duration.ofSeconds(5))
     }
   }
 

--- a/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/testhelpers/MockDataReceiver.scala
+++ b/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/testhelpers/MockDataReceiver.scala
@@ -13,7 +13,8 @@ import scala.collection.mutable
 import scala.util.Random
 
 class MockDataReceiver(val connectionString: String, val receiverConsumerGroup: String, val partition: String,
-    var offset: Option[String], val startTime: Option[Instant]) extends DataReceiver with JsonSerialization {
+    var offset: Option[String], val startTime: Option[Instant], val receiveTimeout: Duration
+    ) extends DataReceiver with JsonSerialization {
 
   private val random: Random = new Random
 

--- a/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/testhelpers/TestConfig.scala
+++ b/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/testhelpers/TestConfig.scala
@@ -17,6 +17,7 @@ object TestConfig {
     props.put(IotHubSourceConfig.TaskPartitionOffsetsMap, """{"0":"5","2":"10","3":"-1"}""")
     props.put(IotHubSourceConfig.KafkaTopic, "test")
     props.put(IotHubSourceConfig.BatchSize, "5")
+    props.put(IotHubSourceConfig.ReceiveTimeout, "5")
     props
   }
 
@@ -28,6 +29,7 @@ object TestConfig {
     props.put(IotHubSourceConfig.IotHubStartTime, "2016-12-10T00:00:00Z")
     props.put(IotHubSourceConfig.KafkaTopic, "test")
     props.put(IotHubSourceConfig.BatchSize, "5")
+    props.put(IotHubSourceConfig.ReceiveTimeout, "5")
     props
   }
 
@@ -38,6 +40,7 @@ object TestConfig {
     props.put(IotHubSourceConfig.TaskPartitionOffsetsMap, """{"0":"-1"}""")
     props.put(IotHubSourceConfig.KafkaTopic, "test")
     props.put(IotHubSourceConfig.BatchSize, "5")
+    props.put(IotHubSourceConfig.ReceiveTimeout, "5")
     props
   }
 
@@ -49,6 +52,7 @@ object TestConfig {
     props.put(IotHubSourceConfig.IotHubAccessKeyValue, iotHubKeyValue)
     props.put(IotHubSourceConfig.IotHubPartitions, iotHubPartitions.toString)
     props.put(IotHubSourceConfig.KafkaTopic, "test")
+    props.put(IotHubSourceConfig.ReceiveTimeout, "45")
     props.put(IotHubSourceConfig.IotHubOffset, "-1,5,10,15,-1")
     props
   }

--- a/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/testhelpers/TestIotHubSourceTask.scala
+++ b/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/testhelpers/TestIotHubSourceTask.scala
@@ -2,13 +2,15 @@
 
 package com.microsoft.azure.iot.kafka.connect.source.testhelpers
 
-import java.time.Instant
+import java.time.{Duration, Instant}
 
 import com.microsoft.azure.iot.kafka.connect.source.{DataReceiver, IotHubSourceTask}
 
 class TestIotHubSourceTask extends IotHubSourceTask {
   override def getDataReceiver(connectionString: String, receiverConsumerGroup: String, partition: String,
-                               partitionOffset: Option[String], partitionStartTime: Option[Instant]): DataReceiver = {
-    new MockDataReceiver(connectionString, receiverConsumerGroup, partition, partitionOffset, partitionStartTime)
+                               partitionOffset: Option[String], partitionStartTime: Option[Instant],
+                               receiveTimeout: Duration): DataReceiver = {
+    new MockDataReceiver(connectionString, receiverConsumerGroup, partition, partitionOffset, partitionStartTime,
+      receiveTimeout)
   }
 }


### PR DESCRIPTION
- Adds a new config `ReceiveTimeout` that lets you control the maximum amount of time a PartitionReceiver will attempt to get events from an eventhub.
- Updates the version to 0.6.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/toketi-kafka-connect-iothub/13)
<!-- Reviewable:end -->
