### PR TITLE
Update log message format

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-val iotHubKafkaConnectVersion = "0.6.1"
+val iotHubKafkaConnectVersion = "0.6.2"
 
 name := "kafka-connect-iothub"
 organization := "com.microsoft.azure.iot"

--- a/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubPartitionSource.scala
+++ b/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubPartitionSource.scala
@@ -16,6 +16,7 @@ class IotHubPartitionSource(val dataReceiver: DataReceiver,
     val partition: String,
     val topic: String,
     val batchSize: Int,
+    val eventHubName: String,
     val sourcePartition: Map[String, String])
   extends LazyLogging
     with JsonSerialization {

--- a/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubPartitionSource.scala
+++ b/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubPartitionSource.scala
@@ -23,16 +23,17 @@ class IotHubPartitionSource(val dataReceiver: DataReceiver,
 
   def getRecords: List[SourceRecord] = {
 
-    logger.debug(s"Polling for data from Partition $partition")
+    logger.debug(s"Polling for data from eventHub $eventHubName partition $partition")
     val list = ListBuffer.empty[SourceRecord]
     try {
       val messages: Iterable[IotMessage] = this.dataReceiver.receiveData(batchSize)
 
       if (messages.isEmpty) {
-        logger.debug(s"Finished processing all messages from partition ${this.partition}")
+        logger.debug(s"Finished processing all messages from eventHub $eventHubName " +
+          s"partition ${this.partition}")
       } else {
-        logger.debug(s"Received ${messages.size} messages from partition ${this.partition} " +
-          s"(requested $batchSize batch)")
+        logger.debug(s"Received ${messages.size} messages from eventHub $eventHubName " +
+          s"partition ${this.partition} (requested $batchSize batch)")
 
         for (msg: IotMessage <- messages) {
 
@@ -46,8 +47,8 @@ class IotHubPartitionSource(val dataReceiver: DataReceiver,
       }
     } catch {
       case NonFatal(e) =>
-        val errorMsg = s"Error while getting SourceRecords for partition ${this.partition}. " +
-          s"Exception - ${e.toString} Stack trace - ${e.printStackTrace()}"
+        val errorMsg = s"Error while getting SourceRecords for eventHub $eventHubName " +
+          s"partition $partition. Exception - ${e.toString} Stack trace - ${e.printStackTrace()}"
         logger.error(errorMsg)
         throw new ConnectException(errorMsg, e)
     }

--- a/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceTask.scala
+++ b/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceTask.scala
@@ -30,8 +30,8 @@ class IotHubSourceTask extends SourceTask with LazyLogging with JsonSerializatio
       for (partitionSource <- this.partitionSources) {
         logger.debug(s"Polling for data in partition ${partitionSource.partition}")
         val sourceRecordsList = partitionSource.getRecords
-        logger.info(s"${eventHubName}:${partitionSource.partition} - Polling for data - " +
-          s"Obtained ${sourceRecordsList.length} SourceRecords")
+        logger.info(s"Polling for data - Obtained ${sourceRecordsList.length} SourceRecords " +
+          s"from ${eventHubName}:${partitionSource.partition}")
         list ++= sourceRecordsList
       }
     } catch {

--- a/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/testhelpers/TestConfig.scala
+++ b/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/testhelpers/TestConfig.scala
@@ -13,6 +13,7 @@ object TestConfig {
   lazy val sourceTaskTestProps: util.Map[String, String] = {
     val props = new util.HashMap[String, String]()
     props.put(IotHubSourceConfig.EventHubCompatibleConnectionString, connStr.toString)
+    props.put(IotHubSourceConfig.EventHubCompatibleName, iotHubName)
     props.put(IotHubSourceConfig.IotHubConsumerGroup, "$Default")
     props.put(IotHubSourceConfig.TaskPartitionOffsetsMap, """{"0":"5","2":"10","3":"-1"}""")
     props.put(IotHubSourceConfig.KafkaTopic, "test")
@@ -23,6 +24,7 @@ object TestConfig {
   lazy val sourceTaskTestPropsStartTime: util.Map[String, String] = {
     val props = new util.HashMap[String, String]()
     props.put(IotHubSourceConfig.EventHubCompatibleConnectionString, connStr.toString)
+    props.put(IotHubSourceConfig.EventHubCompatibleName, iotHubName)
     props.put(IotHubSourceConfig.IotHubConsumerGroup, "$Default")
     props.put(IotHubSourceConfig.TaskPartitionOffsetsMap, """{"0":"5","2":"10","3":"-1"}""")
     props.put(IotHubSourceConfig.IotHubStartTime, "2016-12-10T00:00:00Z")
@@ -34,6 +36,7 @@ object TestConfig {
   lazy val sourceSingleTaskTestProps: util.Map[String, String] = {
     val props = new util.HashMap[String, String]()
     props.put(IotHubSourceConfig.EventHubCompatibleConnectionString, connStr.toString)
+    props.put(IotHubSourceConfig.EventHubCompatibleName, iotHubName)
     props.put(IotHubSourceConfig.IotHubConsumerGroup, "$Default")
     props.put(IotHubSourceConfig.TaskPartitionOffsetsMap, """{"0":"-1"}""")
     props.put(IotHubSourceConfig.KafkaTopic, "test")


### PR DESCRIPTION
Adds the **eventhub name** and the **partition ID** that the `partitionSource` is polling from to the info-level log mesage. This PR basically changes the log message from:
```shell
2018-01-15T19:21:32.609929923Z [2018-01-15 19:21:32,609] INFO Polling for data - Obtained 100 SourceRecords from IotHub (com.microsoft.azure.iot.kafka.connect.source.IotHubSourceTask)
```
to:
```shell
2018-01-15T19:21:32.609929923Z [2018-01-15 19:21:32,609] INFO Polling for data - Obtained 100 SourceRecords from testhub:1 (com.microsoft.azure.iot.kafka.connect.source.IotHubSourceTask)
```
...where `testhub:1` refers to partition 1 of iothub "testhub"

 When multiple kafka-connect-iothub connectors are polling data from different sources, it's nice to see through an info-level log message what source partition is actually being polled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/toketi-kafka-connect-iothub/14)
<!-- Reviewable:end -->
