### PR TITLE
CI/CD pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: scala
+scala:
+   - 2.9.3
+   - 2.10.6
+   - 2.11.11
+   - 2.12.2
+script:
+  - sbt -DscalaVersion=$TRAVIS_SCALA_VERSION assembly
+deploy:
+  provider: releases
+  api_key:
+    secure: YOUR_API_KEY_ENCRYPTED
+  file_glob: true
+  file: target/scala-*/kafka-connect-iothub-assembly_*.jar
+  skip_cleanup: true
+  on:
+    branch: master
+    scala: '2.11.11'
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,19 @@
+jdk: oraclejdk8
 language: scala
 scala:
 - 2.11.11
 - 2.12.2
+cache:
+  directories:
+  - "$HOME/.ivy2"
+  - "$HOME/.sbt"
+  - "$HOME/.m2"
 script:
 - sbt -DscalaVersion=$TRAVIS_SCALA_VERSION assembly
 deploy:
   provider: releases
   api_key:
-    secure: pH3qOqoZQYf6G7HMG9gPfaLGxElyi0HN0jlee+mdqGKU/xfULjNIah0gp3JlHdDqkfm+jOBMxjjICqtEwXtLnyd9YJ+W/ZyzS4hhIJadhh3Mcb/8UvZ+dAw3bsCQ70HAjfevwTPaE/kbbLuoeKWfO3MLjjEYX3Q4KVMegUw7PjSy2KleVI6t9KDYwqmTqpaes66k8U9hQx6mGBbwt761G9V8UOb9Eo1OqhG0OaoEjlo+5fd3e7fI41i4pRNAMgGBe27pjKBywUFZPHe089/7SyWxfrbdHei8iU3IEBVA8tAtzydHnq2C1rj7x42KkIkn7tH/g/zZYCTai0BwomWKLzaDf3x1ZueMpReCPpH/ILHiiDkfqzfmQ+YfQvDbvmsoWIXRCiLZeB9sc6ccEsK53q/Mqa2fdICUFtDeS7yUwovC0NZqJvnGgr2g20y/StR48XhScMjKDWOsHYmMcXQ/Fb0n9ZZPuay0t48WXhI5fqx9GJ6jY6FZJ1SpDwuZRQYaVKXr+Y9kHnMXWXMd2pJgew4XWZQW9XFdZsYBGGCb5eIpEnW3wmbPimCWKWfw3Mk5BNUnO9HsNmvOS01+isvX5eMHTxwIdH/CuFy75IocnA8of2ju4HG4cQaRMnDLc5n5/eUOTd+41ig13hEe9cv+jFTGhvk6BbQ6bGF6tvgr5Zk=
+    secure: $GITHUB_KEY
   file_glob: true
   file: target/scala-*/kafka-connect-iothub-assembly_*.jar
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: scala
 scala:
-- 2.9.3
-- 2.10.6
 - 2.11.11
 - 2.12.2
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: scala
 scala:
-   - 2.9.3
-   - 2.10.6
-   - 2.11.11
-   - 2.12.2
+- 2.9.3
+- 2.10.6
+- 2.11.11
+- 2.12.2
 script:
-  - sbt -DscalaVersion=$TRAVIS_SCALA_VERSION assembly
+- sbt -DscalaVersion=$TRAVIS_SCALA_VERSION assembly
 deploy:
   provider: releases
   api_key:
-    secure: YOUR_API_KEY_ENCRYPTED
+    secure: pH3qOqoZQYf6G7HMG9gPfaLGxElyi0HN0jlee+mdqGKU/xfULjNIah0gp3JlHdDqkfm+jOBMxjjICqtEwXtLnyd9YJ+W/ZyzS4hhIJadhh3Mcb/8UvZ+dAw3bsCQ70HAjfevwTPaE/kbbLuoeKWfO3MLjjEYX3Q4KVMegUw7PjSy2KleVI6t9KDYwqmTqpaes66k8U9hQx6mGBbwt761G9V8UOb9Eo1OqhG0OaoEjlo+5fd3e7fI41i4pRNAMgGBe27pjKBywUFZPHe089/7SyWxfrbdHei8iU3IEBVA8tAtzydHnq2C1rj7x42KkIkn7tH/g/zZYCTai0BwomWKLzaDf3x1ZueMpReCPpH/ILHiiDkfqzfmQ+YfQvDbvmsoWIXRCiLZeB9sc6ccEsK53q/Mqa2fdICUFtDeS7yUwovC0NZqJvnGgr2g20y/StR48XhScMjKDWOsHYmMcXQ/Fb0n9ZZPuay0t48WXhI5fqx9GJ6jY6FZJ1SpDwuZRQYaVKXr+Y9kHnMXWXMd2pJgew4XWZQW9XFdZsYBGGCb5eIpEnW3wmbPimCWKWfw3Mk5BNUnO9HsNmvOS01+isvX5eMHTxwIdH/CuFy75IocnA8of2ju4HG4cQaRMnDLc5n5/eUOTd+41ig13hEe9cv+jFTGhvk6BbQ6bGF6tvgr5Zk=
   file_glob: true
   file: target/scala-*/kafka-connect-iothub-assembly_*.jar
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,7 @@ deploy:
     branch: master
     scala: '2.11.11'
     tags: true
+notifications:
+  email:
+    on_success: never
+    on_failure: always

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Kafka Connect Azure IoT Hub
 ________________________
+[![Build Status](https://travis-ci.org/azure/toketi-kafka-connect-iothub.svg?branch=master)](https://travis-ci.org/azure/toketi-kafka-connect-iothub)
 
 Kafka Connect Azure IoT Hub consists of 2 connectors - a source connector and a sink connector. The source connector
 is used to pump data from [Azure IoT Hub](https://azure.microsoft.com/en-us/services/iot-hub/) to

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-val iotHubKafkaConnectVersion = util.Properties.propOrNone("version").getOrElse("0.6")
+val iotHubKafkaConnectVersion = util.Properties.propOrNone("version").getOrElse("0.7")
 
 name := "kafka-connect-iothub"
 organization := "com.microsoft.azure.iot"

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-val iotHubKafkaConnectVersion = "0.6"
+val iotHubKafkaConnectVersion = util.Properties.propOrNone("version").getOrElse("0.6")
 
 name := "kafka-connect-iothub"
 organization := "com.microsoft.azure.iot"
 version := iotHubKafkaConnectVersion
 
-scalaVersion := "2.11.8"
+scalaVersion := util.Properties.propOrNone("scalaVersion").getOrElse("2.11.8")
 
 scalacOptions ++= Seq("-deprecation", "-explaintypes", "-unchecked", "-feature")
 


### PR DESCRIPTION
Based on #10 I've added a CI/CD pipeline in Travis. 

- Small changes in `build.sbt`. `version` and `scalaVersion` are now parametrized with default values, so that we can control them from Travis.
- Build is executed against multiple Scala versions (2.11 and 2.12), however GitHub release will only be uploaded for v2.11.
- [GitHub release uploading](https://docs.travis-ci.com/user/deployment/releases/) is enabled and **encrypted** OAuth token was generated using Travis CLI; 
```travis setup releases --force```
All you have to do is login to Travis with your GitHub account, enable CI on this repo, create your encrypted token with Travis CLI and replace it in `.travis.yml`. (**Discard all changes other than the token!!!**)
- The deployment is triggered only when a tag is pushed.
- If a build fails, Travis user will be notified via email.
- Build status is shown in README.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/toketi-kafka-connect-iothub/17)
<!-- Reviewable:end -->
