### PR TITLE
Upgrade azure-eventhubs SDK to v1.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-val iotHubKafkaConnectVersion = "0.6.3"
+val iotHubKafkaConnectVersion = "0.7.0"
 
 name := "kafka-connect-iothub"
 organization := "com.microsoft.azure.iot"

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ scalacOptions ++= Seq("-deprecation", "-explaintypes", "-unchecked", "-feature")
 libraryDependencies ++= {
 
   val kafkaVersion = "0.10.2.1"
-  val azureEventHubSDKVersion = "0.14.0"
+  val azureEventHubSDKVersion = "1.0.0"
   val scalaLoggingVersion = "3.5.0"
   val logbackClassicVersion = "1.1.7"
   val scalaTestVersion = "3.0.0"

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-val iotHubKafkaConnectVersion = "0.6.2"
+val iotHubKafkaConnectVersion = "0.6.3"
 
 name := "kafka-connect-iothub"
 organization := "com.microsoft.azure.iot"

--- a/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceConfig.scala
+++ b/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceConfig.scala
@@ -73,10 +73,6 @@ object IotHubSourceConfig {
   def getConfig(configValues: Map[String, String]): IotHubSourceConfig = {
     new IotHubSourceConfig(configDef, configValues)
   }
-
-  def getEventHubCompatibleNamespace(eventHubCompatibleEndpoint: String): String = {
-    eventHubCompatibleEndpoint.replaceFirst(".*://", "").replaceFirst("\\..*", "")
-  }
 }
 
 class IotHubSourceConfig(configDef: ConfigDef, configValues: Map[String, String])

--- a/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceConnector.scala
+++ b/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceConnector.scala
@@ -6,6 +6,7 @@ import java.net.URI
 import java.util
 
 import com.microsoft.azure.eventhubs.ConnectionStringBuilder
+import com.microsoft.azure.eventhubs.impl.ClientConstants
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.kafka.common.config.{ConfigDef, ConfigException}
 import org.apache.kafka.connect.connector.Task
@@ -18,7 +19,6 @@ import scala.collection.mutable
 
 class IotHubSourceConnector extends SourceConnector with LazyLogging with JsonSerialization {
 
-  var START_OF_STREAM = "-1"
   private[this] var props: Map[String, String] = _
 
   override def taskClass(): Class[_ <: Task] = classOf[IotHubSourceTask]
@@ -45,7 +45,7 @@ class IotHubSourceConnector extends SourceConnector with LazyLogging with JsonSe
           offsets(partition)
         }
         else {
-          this.START_OF_STREAM
+          ClientConstants.START_OF_STREAM
         }
         partitionOffsetsMap += (partition.toString -> partitionOffset)
         partition = partition + maxTasks

--- a/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceConnector.scala
+++ b/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceConnector.scala
@@ -2,6 +2,7 @@
 
 package com.microsoft.azure.iot.kafka.connect.source
 
+import java.net.URI
 import java.util
 
 import com.microsoft.azure.eventhubs.ConnectionStringBuilder
@@ -80,13 +81,11 @@ class IotHubSourceConnector extends SourceConnector with LazyLogging with JsonSe
     }
 
     val iotHubSourceConfig = iotHubSourceConfigOption.get
-    val eventHubCompatibleNamespace = IotHubSourceConfig.getEventHubCompatibleNamespace(
-      iotHubSourceConfig.getString(IotHubSourceConfig.EventHubCompatibleEndpoint))
     val iotHubConnectionString = new ConnectionStringBuilder()
-      .setNamespaceName(eventHubCompatibleNamespace)
-      .setEventHubName(IotHubSourceConfig.EventHubCompatibleName)
-      .setSasKeyName(IotHubSourceConfig.IotHubAccessKeyName)
-      .setSasKey(IotHubSourceConfig.IotHubAccessKeyValue).toString
+      .setEndpoint(new URI(iotHubSourceConfig.getString(IotHubSourceConfig.EventHubCompatibleEndpoint)))
+      .setEventHubName(iotHubSourceConfig.getString(IotHubSourceConfig.EventHubCompatibleName))
+      .setSasKeyName(iotHubSourceConfig.getString(IotHubSourceConfig.IotHubAccessKeyName))
+      .setSasKey(iotHubSourceConfig.getString(IotHubSourceConfig.IotHubAccessKeyValue)).toString
     this.props = Map[String, String](
       IotHubSourceConfig.EventHubCompatibleConnectionString -> iotHubConnectionString,
       IotHubSourceConfig.IotHubOffset -> iotHubSourceConfig.getString(IotHubSourceConfig.IotHubOffset),

--- a/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotMessageConverter.scala
+++ b/src/main/scala/com/microsoft/azure/iot/kafka/connect/source/IotMessageConverter.scala
@@ -5,7 +5,7 @@ package com.microsoft.azure.iot.kafka.connect.source
 import java.time.Instant
 import java.util.Date
 
-import com.microsoft.azure.servicebus.amqp.AmqpConstants
+import com.microsoft.azure.eventhubs.impl.AmqpConstants
 import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
 
 import scala.collection.JavaConverters._

--- a/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceConnectorTest.scala
+++ b/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/IotHubSourceConnectorTest.scala
@@ -104,4 +104,22 @@ class IotHubSourceConnectorTest extends FlatSpec with GivenWhenThen with JsonSer
       connector.start(inputProperties)
     }
   }
+
+  "IotHubSourceConnector" should "create a valid connection string" in {
+    Given("Valid set of input properties")
+    val inputProperties = TestConfig.sourceConnectorTestProps
+    val connector = new IotHubSourceConnector
+
+    When("Start and TaskConfig are called in right order")
+    connector.start(inputProperties)
+    val taskConfig = connector.taskConfigs(1).get(0)
+
+    Then("The TaskConfig has the expected connectionString")
+    val expected = String.format("Endpoint=%s;EntityPath=%s;SharedAccessKeyName=%s;SharedAccessKey=%s",
+      inputProperties.get(IotHubSourceConfig.EventHubCompatibleEndpoint),
+      inputProperties.get(IotHubSourceConfig.EventHubCompatibleName),
+      inputProperties.get(IotHubSourceConfig.IotHubAccessKeyName),
+      inputProperties.get(IotHubSourceConfig.IotHubAccessKeyValue))
+    assert(taskConfig.get(IotHubSourceConfig.EventHubCompatibleConnectionString) == expected)
+  }
 }

--- a/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/IotMessageConverterTest.scala
+++ b/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/IotMessageConverterTest.scala
@@ -5,8 +5,8 @@ package com.microsoft.azure.iot.kafka.connect.source
 import java.text.SimpleDateFormat
 import java.time.Instant
 
+import com.microsoft.azure.eventhubs.impl.AmqpConstants
 import com.microsoft.azure.iot.kafka.connect.source.testhelpers.DeviceTemperature
-import com.microsoft.azure.servicebus.amqp.AmqpConstants
 import org.apache.kafka.connect.data.Struct
 import org.json4s.jackson.Serialization._
 import org.scalatest.{FlatSpec, GivenWhenThen}

--- a/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/testhelpers/MockDataReceiver.scala
+++ b/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/testhelpers/MockDataReceiver.scala
@@ -5,8 +5,8 @@ package com.microsoft.azure.iot.kafka.connect.source.testhelpers
 import java.text.SimpleDateFormat
 import java.time.{Duration, Instant}
 
+import com.microsoft.azure.eventhubs.impl.AmqpConstants
 import com.microsoft.azure.iot.kafka.connect.source.{DataReceiver, IotMessage, JsonSerialization}
-import com.microsoft.azure.servicebus.amqp.AmqpConstants
 import org.json4s.jackson.Serialization.write
 
 import scala.collection.mutable

--- a/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/testhelpers/TestConfig.scala
+++ b/src/test/scala/com/microsoft/azure/iot/kafka/connect/source/testhelpers/TestConfig.scala
@@ -2,10 +2,11 @@
 
 package com.microsoft.azure.iot.kafka.connect.source.testhelpers
 
+import java.net.URI
 import java.util
 
+import com.microsoft.azure.eventhubs.ConnectionStringBuilder
 import com.microsoft.azure.iot.kafka.connect.source.IotHubSourceConfig
-import com.microsoft.azure.servicebus.ConnectionStringBuilder
 import com.typesafe.config.ConfigFactory
 
 object TestConfig {
@@ -88,5 +89,9 @@ object TestConfig {
   lazy private val iotHubKeyName    = iotHubConfig.getString("keyName")
   lazy private val iotHubKeyValue   = iotHubConfig.getString("key")
   lazy private val iotHubPartitions = iotHubConfig.getInt("partitions")
-  lazy private val connStr          = new ConnectionStringBuilder(iotHubEndpoint, iotHubName, iotHubKeyName, iotHubKeyValue)
+  lazy private val connStr          = new ConnectionStringBuilder()
+                                        .setEndpoint(new URI(iotHubEndpoint))
+                                        .setEventHubName(iotHubName)
+                                        .setSasKeyName(iotHubKeyName)
+                                        .setSasKey(iotHubKeyValue)
 }


### PR DESCRIPTION
Upgrades this connector to use the latest version of [azure-eventhubs](https://github.com/Azure/azure-event-hubs-java).

Why? I'm hoping this will improve the stability of this connector. I often have tasks enter a failed state that seem to be caused by Azure EventHub resources being temporarily unavailable (see #12). My understanding is that the azure-eventhubs SDK should handle this through it's default retryPolicy, but it didn't seem to be helping under the old version of azure-eventhubs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/toketi-kafka-connect-iothub/18)
<!-- Reviewable:end -->
