### PR TITLE
Updated library minor versions and Kafka major versions to current

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ scalacOptions ++= Seq("-deprecation", "-explaintypes", "-unchecked", "-feature",
 libraryDependencies ++= {
 
   val kafkaVersion = "2.4.1"
-  val azureEventHubSDKVersion = "3.0.2"
+  val azureEventHubSDKVersion = "1.3.0"
   val scalaLoggingVersion = "3.9.2"
   val logbackClassicVersion = "1.2.3"
   val scalaTestVersion = "3.1.1"

--- a/build.sbt
+++ b/build.sbt
@@ -1,25 +1,25 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-val iotHubKafkaConnectVersion = "0.7.0"
+val iotHubKafkaConnectVersion = "0.7.1"
 
 name := "kafka-connect-iothub"
 organization := "com.microsoft.azure.iot"
 version := iotHubKafkaConnectVersion
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.11.12"
 
-scalacOptions ++= Seq("-deprecation", "-explaintypes", "-unchecked", "-feature")
+scalacOptions ++= Seq("-deprecation", "-explaintypes", "-unchecked", "-feature", "-target:jvm-1.8")
 
 libraryDependencies ++= {
 
-  val kafkaVersion = "0.10.2.1"
-  val azureEventHubSDKVersion = "1.0.0"
-  val scalaLoggingVersion = "3.5.0"
-  val logbackClassicVersion = "1.1.7"
-  val scalaTestVersion = "3.0.0"
-  val configVersion = "1.3.1"
-  val json4sVersion = "3.5.0"
-  val iotHubServiceClientVersion = "1.4.22"
+  val kafkaVersion = "2.4.1"
+  val azureEventHubSDKVersion = "3.0.2"
+  val scalaLoggingVersion = "3.9.2"
+  val logbackClassicVersion = "1.2.3"
+  val scalaTestVersion = "3.1.1"
+  val configVersion = "1.4.0"
+  val json4sVersion = "3.6.7"
+  val iotHubServiceClientVersion = "1.21.1"
 
   Seq(
     "org.apache.kafka" % "connect-api" % kafkaVersion % "provided",

--- a/project/PackagingTypeWorkaround.scala
+++ b/project/PackagingTypeWorkaround.scala
@@ -1,0 +1,18 @@
+/*
+This is a workaround to fix the inability of sbt to resolve ${packaging.type}
+
+[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
+[warn] 	::              FAILED DOWNLOADS            ::
+[warn] 	:: ^ see resolution messages for details  ^ ::
+[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
+[warn] 	:: javax.ws.rs#javax.ws.rs-api;2.1.1!javax.ws.rs-api.${packaging.type}
+[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
+*/
+import sbt._
+
+object PackagingTypeWorkaround extends AutoPlugin {
+  override val buildSettings = {
+    sys.props += "packaging.type" -> "jar"
+    Nil
+  }
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.12
+sbt.version = 0.13.18


### PR DESCRIPTION
Some simple changes here to bring the minor versions up to date knowing that the Azure EventHubs SDK has changed quite a bit and that ideally this connector would be refactored to use the latest  azure-messaging-eventhubs package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/toketi-kafka-connect-iothub/27)
<!-- Reviewable:end -->
